### PR TITLE
fix: TypeError on window closed

### DIFF
--- a/hanfor/telemetry/telemetry.py
+++ b/hanfor/telemetry/telemetry.py
@@ -49,7 +49,7 @@ class TelemetryWs(Namespace):
             emit("command", "no_telemetry")
             disconnect()
 
-    def on_disconnect(self):
+    def on_disconnect(self, _reason):
         # end last event if needed
         sid = request.sid  # noqa sid exists for request
         if (


### PR DESCRIPTION
`TelemetryWs` throws `TypeError` when a window is closed. This PR fixes that.

## Reproduction steps

1. Launch Hanfor
2. Open a window
3. Close window

Following logs should be observed:

```
Traceback (most recent call last):
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/engineio/server.py", line 450, in run_handler
    return self.handlers[event](*args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/socketio/server.py", line 671, in _handle_eio_disconnect
    self._handle_disconnect(eio_sid, n, reason)
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/socketio/server.py", line 568, in _handle_disconnect
    self._trigger_event('disconnect', namespace, sid,
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/socketio/server.py", line 627, in _trigger_event
    return handler.trigger_event(event, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/flask_socketio/namespace.py", line 25, in trigger_event
    return self.socketio._handle_event(handler, event, self.namespace,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/flask_socketio/__init__.py", line 833, in _handle_event
    ret = handler(*args)
          ^^^^^^^^^^^^^^
TypeError: TelemetryWs.on_disconnect() takes 1 positional argument but 2 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/engineio/server.py", line 456, in run_handler
    return self.handlers[event](args[0])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Server._handle_eio_disconnect() missing 1 required positional argument: 'reason'
[25-01-03 12:48:07 server.py:460] ERROR - disconnect handler error
Traceback (most recent call last):
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/engineio/server.py", line 450, in run_handler
    return self.handlers[event](*args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/socketio/server.py", line 671, in _handle_eio_disconnect
    self._handle_disconnect(eio_sid, n, reason)
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/socketio/server.py", line 568, in _handle_disconnect
    self._trigger_event('disconnect', namespace, sid,
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/socketio/server.py", line 627, in _trigger_event
    return handler.trigger_event(event, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/flask_socketio/namespace.py", line 25, in trigger_event
    return self.socketio._handle_event(handler, event, self.namespace,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/flask_socketio/__init__.py", line 833, in _handle_event
    ret = handler(*args)
          ^^^^^^^^^^^^^^
TypeError: TelemetryWs.on_disconnect() takes 1 positional argument but 2 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aiono/Documents/Master/Hanfor/hanfor/hanfor_venv/lib/python3.12/site-packages/engineio/server.py", line 456, in run_handler
    return self.handlers[event](args[0])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Server._handle_eio_disconnect() missing 1 required positional argument: 'reason'
```

Looks like the cause is when window is closed `TelemetryWs.on_disconnect` is called with a positional argument `reason`. But implemented class doesn't accept any additional argument. Adding that argument fixes the error.
