### PR TITLE
Replace singleton smt solver instance by per-request solver

### DIFF
--- a/hanfor/lib_core/data.py
+++ b/hanfor/lib_core/data.py
@@ -497,13 +497,14 @@ class Expression:
 class Pattern:
     def __init__(self, name: str = "NotFormalizable"):
         # Hack: reflect over pattern class to update to correct name
-        self.name = APattern().get_pattern(name).__class__.__name__
-        self.pattern = APattern().get_pattern(name)._pattern_text
-        self.environment = APattern().get_pattern(name)._env
+        pattern = APattern.get_pattern(name)
+        self.name = pattern.__name__
+        self.pattern = pattern()._pattern_text
+        self.environment = pattern()._env
 
     def get_patternish(self) -> APattern:
         # TODO: find good name for pattern template
-        return APattern().get_pattern(self.get_name())
+        return APattern.get_pattern(self.get_name())()
 
     def get_name(self):
         return self.name
@@ -518,7 +519,7 @@ class Pattern:
         return self.pattern
 
     def get_allowed_types(self):
-        return BoogieType.alias_env_to_instantiated_env(self.get_patternish()._env)
+        return BoogieType.alias_env_to_instantiated_env(self.get_patternish().env)
 
 
 @DatabaseFieldType()
@@ -947,7 +948,7 @@ class VariableCollection:
             self.rename(old_enumerator_name, new_enumerator_name, app)
         return affected_enumerators
 
-    def get_boogie_type_env(self):
+    def get_boogie_type_env(self) -> dict[str, BoogieType]:
         mapping = {
             "bool": boogie_parsing.BoogieType.bool,
             "int": boogie_parsing.BoogieType.int,

--- a/hanfor/lib_core/pattern/patterns_automata.py
+++ b/hanfor/lib_core/pattern/patterns_automata.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class AAutomatonPattern(APattern):
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         self.group = "Abstract"
 
@@ -53,10 +53,11 @@ class AAutomatonPattern(APattern):
     ) -> list["Formalization"]:
         transitions = []
         fmgr = smt_env.formula_manager
-        for source, formalization in transitions_by_source:
-            # Semantic check as location may be syntactically different in any reference (as it is written by hand).
-            if smt_env.factory.get_solver(name="z3").is_valid(fmgr.Iff(location, source)):
-                transitions.append(formalization)
+        with smt_env.factory.get_solver(name="z3") as solver:
+            for source, formalization in transitions_by_source:
+                # Semantic check as location may be syntactically different in any reference (as it is written by hand).
+                if solver.is_valid(fmgr.Iff(location, source)):
+                    transitions.append(formalization)
         return transitions
 
     @staticmethod

--- a/hanfor/lib_core/pattern/patterns_automata.py
+++ b/hanfor/lib_core/pattern/patterns_automata.py
@@ -1,12 +1,12 @@
 from typing import Iterable, TYPE_CHECKING
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import Iff, Not, is_valid, FALSE, Or, And, simplify, TRUE
 from typing_extensions import override
 
 from lib_core.pattern.patterns_basic import APattern
 from lib_core.scopes import Scope
-from lib_pea.countertrace import Countertrace, phaseT, phase
+from lib_pea.countertrace import Countertrace, phaseT, phase, BoundTypes
 from lib_pea.formal_utils import get_smt_expression
 
 if TYPE_CHECKING:
@@ -14,54 +14,57 @@ if TYPE_CHECKING:
     from lib_core.data import VariableCollection
 
 
-SOLVER_NAME = "z3"
-LOGIC = "UFLIRA"
-
-
 class AAutomatonPattern(APattern):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.group = "Abstract"
 
-    def get_target_location(self, f: "Formalization", vc: "VariableCollection") -> "FNode":
+    def get_target_location(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> "FNode":
         """Return the expression identifying the successor.
         Patterns might have a different placeholder assigned for the successor, so allow resolution here"""
-        return get_smt_expression(f, vc, "S")
+        return get_smt_expression(smt_env, f, vc, "S")
 
-    def get_source_location(self, f: "Formalization", vc: "VariableCollection") -> "FNode":
-        return get_smt_expression(f, vc, "R")
+    def get_source_location(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> "FNode":
+        return get_smt_expression(smt_env, f, vc, "R")
 
-    def get_locations(self, f: "Formalization", vc: "VariableCollection") -> set["FNode"]:
-        return {self.get_source_location(f, vc), self.get_target_location(f, vc)}
+    def get_locations(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> set["FNode"]:
+        return {self.get_source_location(smt_env, f, vc), self.get_target_location(smt_env, f, vc)}
 
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
         # Just see non-guarded edges as true
-        return TRUE()
+        fmgr = smt_env.formula_manager
+        return fmgr.TRUE()
 
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
         # there is no diffecrence between an event always being true versus no event being there
-        return TRUE()
+        fmgr = smt_env.formula_manager
+        return fmgr.TRUE()
 
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.NONE
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.NONE
 
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return TRUE()
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        fmgr = smt_env.formula_manager
+        return fmgr.TRUE()
 
     @staticmethod
     def __find_successors(
-        location: "Expression", transitions_by_source: list[tuple["Expression", "Formalization"]]
+        smt_env: Environment, location: "Expression", transitions_by_source: list[tuple["Expression", "Formalization"]]
     ) -> list["Formalization"]:
         transitions = []
+        fmgr = smt_env.formula_manager
         for source, formalization in transitions_by_source:
             # Semantic check as location may be syntactically different in any reference (as it is written by hand).
-            if is_valid(Iff(location, source)):
+            if smt_env.factory.get_solver(name="z3").is_valid(fmgr.Iff(location, source)):
                 transitions.append(formalization)
         return transitions
 
     @staticmethod
     def get_hull(
-        formalization: "Formalization", other_f: Iterable["Formalization"], vc: "VariableCollection"
+        smt_env: Environment,
+        formalization: "Formalization",
+        other_f: Iterable["Formalization"],
+        vc: "VariableCollection",
     ) -> set["Formalization"]:
         """Figure out what patterns belong to the automaton of `req`.
         This is done by building the hull of all edges.
@@ -73,19 +76,21 @@ class AAutomatonPattern(APattern):
             pattern = f.scoped_pattern.get_patternish()
             if not isinstance(pattern, AAutomatonPattern):
                 continue
-            transitions_by_source.append((pattern.get_source_location(f, vc), f))
+            transitions_by_source.append((pattern.get_source_location(smt_env, f, vc), f))
         initials_by_target: list[tuple["FNode", "Formalization"]] = []
         for f in other_f:
             pattern = f.scoped_pattern.get_patternish()
             if isinstance(pattern, InitialLoc):
-                initials_by_target.append((pattern.get_target_location(f, vc), f))
+                initials_by_target.append((pattern.get_target_location(smt_env, f, vc), f))
 
         automaton = {formalization}
         queue = [formalization]
         while queue:
             pivot = queue.pop()
-            pattern = pivot.scoped_pattern.get_patternish()  # noqa
-            successors = pattern.__find_successors(pattern.get_target_location(pivot, vc), transitions_by_source)
+            pattern = pivot.scoped_pattern.get_patternish()
+            successors = pattern.__find_successors(
+                smt_env, pattern.get_target_location(smt_env, pivot, vc), transitions_by_source
+            )
             for f in [f for f in successors if f not in automaton]:
                 automaton.add(f)
                 queue.append(f)
@@ -94,150 +99,182 @@ class AAutomatonPattern(APattern):
         initials = set()
         for f in automaton:
             pattern = f.scoped_pattern.get_patternish()
-            initials.update(pattern.__find_successors(pattern.get_source_location(f, vc), initials_by_target))
-            initials.update(pattern.__find_successors(pattern.get_target_location(f, vc), initials_by_target))
+            initials.update(
+                pattern.__find_successors(smt_env, pattern.get_source_location(smt_env, f, vc), initials_by_target)
+            )
+            initials.update(
+                pattern.__find_successors(smt_env, pattern.get_target_location(smt_env, f, vc), initials_by_target)
+            )
         automaton.update(initials)
         return automaton
 
     def _get_instanciated_coutertrace(
         self,
+        smt_env: Environment,
         scope: str,
         this_f: "Formalization",
         other_f: list["Formalization"],
         vc: "VariableCollection",
     ) -> list[Countertrace]:
         self._fail_wrong_scope(scope)
-        aut = self.get_hull(this_f, other_f, vc)
+        aut = self.get_hull(smt_env, this_f, other_f, vc)
 
-        source_loc = self.get_source_location(this_f, vc)
-        target_loc = self.get_target_location(this_f, vc)
+        source_loc = self.get_source_location(smt_env, this_f, vc)
+        target_loc = self.get_target_location(smt_env, this_f, vc)
         other_edges = []
         for of in aut:
             f_pat = of.scoped_pattern.get_patternish()
             if isinstance(f_pat, InitialLoc):
                 continue
-            if f_pat.get_source_location(of, vc) != source_loc:
+            if f_pat.get_source_location(smt_env, of, vc) != source_loc:
                 continue
             # this will also include this transition so no special case is required
-            other_edges.append((f_pat.get_guard(of, vc), f_pat.get_event(of, vc), f_pat.get_target_location(of, vc)))
+            other_edges.append(
+                (
+                    f_pat.get_guard(smt_env, of, vc),
+                    f_pat.get_event(smt_env, of, vc),
+                    f_pat.get_target_location(smt_env, of, vc),
+                )
+            )
 
         this_pat = this_f.scoped_pattern.get_patternish()
         return self._generic_transition_builder(
+            smt_env,
             source_loc,
             target_loc,
-            this_pat.get_event(this_f, vc),
-            this_pat.get_guard(this_f, vc),
+            this_pat.get_event(smt_env, this_f, vc),
+            this_pat.get_guard(smt_env, this_f, vc),
             other_edges,
             this_pat.get_bound_type(),
-            this_pat.get_bound(this_f, vc),
+            this_pat.get_bound(smt_env, this_f, vc),
         )
 
     def _generic_transition_builder(
         self,
+        smt_env: Environment,
         source_loc: FNode,
         target_loc: FNode,
-        source_event: FNode = None,  # the event of the transition we want to encode here
-        guard: FNode = None,
-        outgoing_edges: list[tuple[FNode, FNode, FNode]] = None,  #  location, guard, event i.e. (g_j, e_j, l_)
-        bound_type: Countertrace.BoundTypes = Countertrace.BoundTypes.NONE,
+        source_event: FNode | None = None,  # the event of the transition we want to encode here
+        guard: FNode | None = None,
+        outgoing_edges: list[tuple[FNode, FNode, FNode]] | None = None,  #  location, guard, event i.e. (g_j, e_j, l_)
+        bound_type: BoundTypes = BoundTypes.NONE,
         time_bound: float = 0.0,
     ) -> list["Countertrace"]:
         """
         Generate different formulas to get CTs equivalent to the automaton, see (TODO: doi for the old paper)
         """
         result = []
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
         outgoing_edges = [] if outgoing_edges is None else outgoing_edges
         # build formula for event is set from entry (event is true and stays true)                     (see Formula 17)
-        result.append(self.__build_edge_event_locked(source_loc, source_event, outgoing_edges))
+        result.append(self.__build_edge_event_locked(smt_env, source_loc, source_event, outgoing_edges))
         # build formula for event is not set (and may trigger a trainsition)                           (see Formula 18)
-        if source_event != TRUE():
-            result.append(self.__build_edge_event_armed(source_loc, source_event, outgoing_edges))
+        if source_event != fmgr.TRUE():
+            result.append(self.__build_edge_event_armed(smt_env, source_loc, source_event, outgoing_edges))
         # build formulas for time bounds in locations                                                  (see Formula 20)
-        if bound_type is not Countertrace.BoundTypes.NONE:
+        if bound_type is not BoundTypes.NONE:
             result.append(
                 self._build_edge_time_bound(
-                    source_loc, target_loc, guard, bound_type, time_bound, source_event, outgoing_edges
+                    smt_env, source_loc, target_loc, guard, bound_type, time_bound, source_event, outgoing_edges
                 )
             )
         return result
 
     def __build_edge_event_locked(
         self,
+        smt_env: Environment,
         source_loc: FNode,
-        source_event: FNode = None,  # the event of the transition we want to encode here
-        outgoing_edges: list[tuple[FNode, FNode, FNode]] = None,  #  location, guard, event i.e. (g_j, e_j, l_)
+        source_event: FNode | None = None,  # the event of the transition we want to encode here
+        outgoing_edges: list[tuple[FNode, FNode, FNode]] | None = None,  #  location, guard, event i.e. (g_j, e_j, l_)
     ) -> Countertrace:
-        ct_eset = Countertrace()
-        ct_eset.dc_phases.append(phaseT())
+        if outgoing_edges is None:
+            outgoing_edges = []
+        fmgr = smt_env.formula_manager
+        ct_eset = Countertrace(smt_env)
+        ct_eset.dc_phases.append(phaseT(smt_env))
         if not source_event:
-            ct_eset.dc_phases.append(phase(source_loc))
+            ct_eset.dc_phases.append(phase(smt_env, source_loc))
         else:
-            ct_eset.dc_phases.append(phase(And(source_loc, source_event)))
+            ct_eset.dc_phases.append(phase(smt_env, fmgr.And(source_loc, source_event)))
         all_target_expr = []
         for g, e, l in outgoing_edges:
-            if e is not TRUE() and e == source_event:
+            if e is not fmgr.TRUE() and e == source_event:
                 continue
-            e_expr = e if e else TRUE()
-            all_target_expr.append(And(l, g, e_expr))
-        expr = Not(Or(source_loc, *all_target_expr))
-        ct_eset.dc_phases.append(phase(simplify(expr)))
-        ct_eset.dc_phases.append(phaseT())
+            e_expr = e if e else fmgr.TRUE()
+            all_target_expr.append(fmgr.And(l, g, e_expr))
+        expr = fmgr.Not(fmgr.Or(source_loc, *all_target_expr))
+        ct_eset.dc_phases.append(phase(smt_env, smt_env.simplifier.simplify(expr)))
+        ct_eset.dc_phases.append(phaseT(smt_env))
         return ct_eset
 
     def __build_edge_event_armed(
         self,
+        smt_env: Environment,
         source_loc: FNode,
-        source_event: FNode = None,  # the event of the transition we want to encode here
-        outgoing_edges: list[tuple[FNode, FNode, FNode]] = None,  #  location, guard, event i.e. (g_j, e_j, l_j)
+        source_event: FNode | None = None,  # the event of the transition we want to encode here
+        outgoing_edges: list[tuple[FNode, FNode, FNode]] | None = None,  #  location, guard, event i.e. (g_j, e_j, l_j)
     ) -> Countertrace:
-        ct_enot = Countertrace()
-        ct_enot.dc_phases.append(phaseT())
-        ct_enot.dc_phases.append(phase(And(source_loc, Not(source_event))))
+        if outgoing_edges is None:
+            outgoing_edges = []
+        fmgr = smt_env.formula_manager
+        ct_enot = Countertrace(smt_env)
+        ct_enot.dc_phases.append(phaseT(smt_env))
+        ct_enot.dc_phases.append(phase(smt_env, fmgr.And(source_loc, fmgr.Not(source_event))))
         all_target_expr = []
         for g, e, l in outgoing_edges:
-            all_target_expr.append(And(l, g, e))
-        expr = Not(Or(And(source_loc, Not(source_event)), *all_target_expr))
-        ct_enot.dc_phases.append(phase(simplify(expr)))
-        ct_enot.dc_phases.append(phaseT())
+            all_target_expr.append(fmgr.And(l, g, e))
+        expr = fmgr.Not(fmgr.Or(fmgr.And(source_loc, fmgr.Not(source_event)), *all_target_expr))
+        ct_enot.dc_phases.append(phase(smt_env, smt_env.simplifier.simplify(expr)))
+        ct_enot.dc_phases.append(phaseT(smt_env))
         return ct_enot
 
     def _build_edge_time_bound(
         self,
+        smt_env: Environment,
         source_loc: FNode,
         target_loc: FNode,
-        guard: FNode,
-        bound_type: Countertrace.BoundTypes,
+        guard: FNode | None,
+        bound_type: BoundTypes,
         time_bound: float,
-        source_event: FNode = None,  # the event of the transition we want to encode here
-        outgoing_edges: list[tuple[FNode, FNode, FNode]] = None,  #  location, guard, event i.e. (g_j, e_j, l_j)
+        source_event: FNode | None = None,  # the event of the transition we want to encode here
+        outgoing_edges: list[tuple[FNode, FNode, FNode]] | None = None,  #  location, guard, event i.e. (g_j, e_j, l_j)
     ) -> Countertrace:
+        if outgoing_edges is None:
+            outgoing_edges = []
         # build formulas for time bounds in locations                                                  (see Formula 20)
-        ct = Countertrace()
-        ct.dc_phases.append(phaseT())
-        ct.dc_phases.append(phase(source_loc, bound_type.invert(), time_bound))
+        ct = Countertrace(smt_env)
+        ct.dc_phases.append(phaseT(smt_env))
+        ct.dc_phases.append(phase(smt_env, source_loc, bound_type.invert(), time_bound))
         ct.dc_phases.append(
-            phase(self._build_timed_third_phase(source_loc, target_loc, guard, source_event, outgoing_edges))
+            phase(
+                smt_env,
+                self._build_timed_third_phase(smt_env, source_loc, target_loc, guard, source_event, outgoing_edges),
+            )
         )
-        ct.dc_phases.append(phaseT())
+        ct.dc_phases.append(phaseT(smt_env))
         return ct
 
     def _build_timed_third_phase(
         self,
+        smt_env: Environment,
         source_loc: FNode,
         target_loc: FNode,
-        guard: FNode,
-        source_event: FNode,  # the event of the transition we want to encode here
+        guard: FNode | None,
+        source_event: FNode | None,  # the event of the transition we want to encode here
         outgoing_edges: list[tuple[FNode, FNode, FNode]],  #  location, guard, event i.e. (g_j, e_j, l_j)
     ) -> FNode:
+        fmgr = smt_env.formula_manager
         # Violation if: the timed edge is taken and ...
-        pos_f = And(target_loc, guard, source_event)
+        pos_f = fmgr.And(target_loc, guard, source_event)
         # ... none of the other edges could also be taken
-        neg_f = FALSE()
+
+        neg_f = fmgr.FALSE()
         for g, e, l in outgoing_edges:
             if e == source_event and g == guard and source_loc == source_loc:
                 continue
-            neg_f = Or(neg_f, And(g, e, l))
-        return And(pos_f, Not(neg_f))
+            neg_f = fmgr.Or(neg_f, fmgr.And(g, e, l))
+        return fmgr.And(pos_f, fmgr.Not(neg_f))
 
     def _fail_wrong_scope(self, scope: str):
         if scope not in [Scope.GLOBALLY.get_slug(), "Globally", Scope.GLOBALLY]:
@@ -251,28 +288,29 @@ class AAutomatonPattern(APattern):
 
 
 class InitialLoc(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = -1
+    old_names = ["InitialLoc "]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "location {R} is an initial location"
-        self.old_names = ["InitialLoc "]
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = -1
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_source_location(self, f: "Formalization", vc: "VariableCollection") -> "FNode":
+    def get_source_location(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> "FNode":
         # This way we can handle the edge without an exception case
-        return get_smt_expression(f, vc, "R")
+        return get_smt_expression(smt_env, f, vc, "R")
 
     @override
-    def get_target_location(self, f: "Formalization", vc: "VariableCollection") -> "FNode":
-        return get_smt_expression(f, vc, "R")
+    def get_target_location(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> "FNode":
+        return get_smt_expression(smt_env, f, vc, "R")
 
     @override
     def _get_instanciated_coutertrace(
         self,
+        smt_env: Environment,
         scope: str,
         f: "Formalization",
         other_f: list["Formalization"],
@@ -282,275 +320,276 @@ class InitialLoc(AAutomatonPattern):
         e.g. [A || B]; true
         """
         self._fail_wrong_scope(scope)
-        expr = FALSE()
-        aut = self.get_hull(f, other_f, vc)
+        fmgr = smt_env.formula_manager
+        expr = fmgr.FALSE()
+        aut = self.get_hull(smt_env, f, other_f, vc)
         for t in aut:
             if not isinstance(t.scoped_pattern.get_patternish(), InitialLoc):
                 continue
-            expr = Or(expr, get_smt_expression(t, vc, "R"))
-        expr = simplify(expr)
-        ct = Countertrace()
-        ct.dc_phases.append(phase(Not(expr)))
-        ct.dc_phases.append(phaseT())
+            expr = fmgr.Or(expr, get_smt_expression(smt_env, t, vc, "R"))
+        expr = smt_env.simplifier.simplify(expr)
+        ct = Countertrace(smt_env)
+        ct.dc_phases.append(phase(smt_env, fmgr.Not(expr)))
+        ct.dc_phases.append(phaseT(smt_env))
         return [ct]
 
 
 class Transition(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 0
+    old_names = ["Transition"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} then transition to {S} is enabled ."
-        self.old_names = ["Transition"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
 
 class TransitionG(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 1
+    old_names = ["TransitionG"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} then transition to {S} is enabled if guard {V} holds."
-        self.old_names = ["TransitionG"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "V": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 1
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "V")
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "V")
 
 
 class TransitionLG(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 2
+    old_names = ["TransitionLG"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} for at least {T} transition to {S} is enabled if guard {V} holds."
-        self.old_names = ["TransitionLG"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "V": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 2
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "V")
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "V")
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.GREATEREQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.GREATEREQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
 
 class TransitionUG(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 3
+    old_names = ["TransitionUG"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} for at most {T} transition to {S} is enabled if guard {V} holds."
-        self.old_names = ["TransitionUG"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "V": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 3
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.LESSEQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.LESSEQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
     @override
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "V")
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "V")
 
 
 class TransitionL(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 4
+    old_names = ["TransitionL"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} for at least {T} transition to {S} is enabled ."
-        self.old_names = ["TransitionL"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Automaton"
-        self.order: int = 4
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.GREATEREQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.GREATEREQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
 
 class TransitionU(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 5
+    old_names = ["TransitionU"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} for at most {T} transition to {S} is enabled ."
-        self.old_names = ["TransitionU"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Automaton"
-        self.order: int = 5
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.LESSEQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.LESSEQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
 
 class TransitionE(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 6
+    old_names = ["TransitionE"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} then transition to {S} if event {U} fires ."
-        self.old_names = ["TransitionE"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "U": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 6
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "U")
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "U")
 
 
 class TransitionGE(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 7
+    old_names = ["TransitionGE"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} then transition to {S} if event {U} fires and guard {V} holds."
-        self.old_names = ["TransitionGE"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "V": ["bool"], "U": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 7
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "V")
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "V")
 
     @override
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "U")
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "U")
 
 
 class TransitionLE(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 10
+    old_names = ["TransitionLE"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} for at least {T} transition to {S} if event {U} fires ."
-        self.old_names = ["TransitionLE"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "U": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 10
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "U")
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "U")
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.GREATEREQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.GREATEREQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
 
 class TransitionUE(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 11
+    old_names = ["TransitionUE"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "if in location {R} for at most {T} transition to {S} if event {U} fires ."
-        self.old_names = ["TransitionUE"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "U": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 11
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "U")
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "U")
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.LESSEQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.LESSEQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
 
 class TransitionLGE(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 8
+    old_names = ["TransitionLGE"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "if in location {R} for at least {T} transition to {S} if event {U} fires and guard {V} holds."
         )
-        self.old_names = ["TransitionLGE"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "V": ["bool"], "U": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 8
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "V")
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "V")
 
     @override
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "U")
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "U")
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.GREATEREQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.GREATEREQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")
 
 
 class TransitionUGE(AAutomatonPattern):
+    group: str = "Automaton"
+    order: int = 9
+    old_names = ["TransitionUGE"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "if in location {R} for at most {T} transition to {S} if event {U} fires and guard {V} holds."
         )
-        self.old_names = ["TransitionUGE"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "V": ["bool"], "U": ["bool"]}
-        self.group: str = "Automaton"
-        self.order: int = 9
         self._countertraces: dict[str, list[str]] = {"GLOBALLY": []}
 
     @override
-    def get_guard(self, f: "Formalization", vc: "VariableCollection") -> FNode:
+    def get_guard(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
         # Just see non-guarded edges as true
-        return get_smt_expression(f, vc, "V")
+        return get_smt_expression(smt_env, f, vc, "V")
 
     @override
-    def get_event(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "U")
+    def get_event(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "U")
 
     @override
-    def get_bound_type(self) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.LESSEQUAL
+    def get_bound_type(self) -> BoundTypes:
+        return BoundTypes.LESSEQUAL
 
     @override
-    def get_bound(self, f: "Formalization", vc: "VariableCollection") -> FNode:
-        return get_smt_expression(f, vc, "T")
+    def get_bound(self, smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> FNode:
+        return get_smt_expression(smt_env, f, vc, "T")

--- a/hanfor/lib_core/pattern/patterns_basic.py
+++ b/hanfor/lib_core/pattern/patterns_basic.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from pysmt.environment import Environment
+
 from lib_pea.countertrace import Countertrace, CountertraceTransformer
 from lib_pea.formal_utils import get_expression_mapping_smt
 from lib_pea.utils import get_countertrace_parser
@@ -11,13 +13,13 @@ if TYPE_CHECKING:
 
 
 class APattern:
+    group: str = "Abstract"
+    order: int = 0
+    old_names: list[str] = []
 
     def __init__(self):
         self._pattern_text: str = "is an empty Pattern"
-        self.old_names: list[str] = []
         self._env: dict[str, list[str]] = {}
-        self.group: str = "Abstract"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = defaultdict(list)
 
     def get_text(self):
@@ -33,45 +35,56 @@ class APattern:
     def has_countertraces(self, scope: str):
         return scope in self._countertraces and self._countertraces[scope]
 
+    @property
+    def env(self):
+        return self._env
+
     def get_instanciated_countertraces(
         self,
+        smt_env: Environment,
         scope: str,
         f: "Formalization",
         other_f: list["Formalization"],
         variable_collection: "VariableCollection",
     ) -> list[Countertrace]:
-        return self._get_instanciated_coutertrace(scope, f, other_f, variable_collection)
+        return self._get_instanciated_coutertrace(smt_env, scope, f, other_f, variable_collection)
 
     def _get_instanciated_coutertrace(
         self,
+        smt_env: Environment,
         scope: str,
         f: "Formalization",
         other_f: list["Formalization"],
         variable_collection: "VariableCollection",
     ) -> list[Countertrace]:
         cts = []
-        expr = get_expression_mapping_smt(f, variable_collection)
+        expr = get_expression_mapping_smt(smt_env, f, variable_collection)
         for ct_str in self.get_countertraces(scope):
             ct_ast = get_countertrace_parser().parse(ct_str)
-            cts.append(CountertraceTransformer(expr).transform(ct_ast))
+            cts.append(CountertraceTransformer(smt_env, expr).transform(ct_ast))
         return cts
 
-    def get_patterns(self) -> dict[str, "APattern"]:
-        return {t.__name__: t() for t in self.__get_inheriting_pattern(self.__class__) if t().group != "Abstract"}
+    @classmethod
+    def get_patterns(cls) -> dict[str, type["APattern"]]:
+        return {t.__name__: t for t in cls.__get_inheriting_pattern(cls) if t.group != "Abstract"}
 
-    def __get_inheriting_pattern(self, t: type["APattern"]) -> set[type["APattern"]]:
-        result = set(t.__subclasses__())
+    @classmethod
+    def __get_inheriting_pattern(cls, t: type["APattern"]) -> set[type["APattern"]]:
+        # noinspection PyTypeChecker
+        result: set[type["APattern"]] = set(t.__subclasses__())
         for sub in t.__subclasses__():
-            result |= self.__get_inheriting_pattern(sub)
+            # noinspection PyTypeChecker
+            result |= cls.__get_inheriting_pattern(sub)
         return result
 
-    def get_pattern(self, name: str) -> "APattern":
+    @classmethod
+    def get_pattern(cls, name: str) -> type["APattern"]:
         # TODO: search in old names for compatibility reasons
-        patterns = APattern().get_patterns()
+        patterns = cls.get_patterns()
         if name in patterns:
             return patterns[name]
-        by_old_name: dict[str, "APattern"] = dict()
-        for pattern in self.get_patterns().values():
+        by_old_name: dict[str, type["APattern"]] = dict()
+        for pattern in cls.get_patterns().values():
             by_old_name.update({old_name: pattern for old_name in pattern.old_names})
         if name in by_old_name:
             return by_old_name[name]
@@ -80,34 +93,35 @@ class APattern:
     @classmethod
     def to_frontent_dict(cls) -> dict:
         result = dict()
-        for name, pattern in APattern().get_patterns().items():
+        for name, pattern in APattern.get_patterns().items():
+            pattern_inst = pattern()
             result[name] = {
-                "env": pattern._env,
-                "countertraces": pattern._countertraces,
+                "env": pattern_inst._env,
+                "countertraces": pattern_inst._countertraces,
             }
         return result
 
 
 class NotFormalizable(APattern):
+    group: str = "not_formalizable"
+    order: int = 0
+    old_names = ["Plumbing"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "no pattern set"
-        self.old_names = ["Plumbing"]
         self._env: dict[str, list[str]] = {}
-        self.group: str = "not_formalizable"
-        self.order: int = 0
 
 
 class Response(APattern):
+    group: str = "Order"
+    order: int = 0
+    old_names = ["Response"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds then {S} eventually holds"
-        self.old_names = ["Response"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": [],
             "BEFORE": ["⌈!P⌉;⌈(!P && (R && !S))⌉;⌈(!P && !S)⌉;⌈P⌉;true"],
@@ -118,16 +132,16 @@ class Response(APattern):
 
 
 class ResponseChain12(APattern):
+    group: str = "Order"
+    order: int = 2
+    old_names = ["ResponseChain1-2"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds then {S} eventually holds and is succeeded by {T}"
         )
-        self.old_names = ["ResponseChain1-2"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 2
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": [],
             "BEFORE": [
@@ -144,16 +158,16 @@ class ResponseChain12(APattern):
 
 
 class ConstrainedChain(APattern):
+    group: str = "Order"
+    order: int = 4
+    old_names = ["ConstrainedChain"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds then {S} eventually holds and is succeeded by {T}, where {U} does not hold between {S} and {T}"
         )
-        self.old_names = ["ConstrainedChain"]
         self._env: dict[str, list[str]] = {"U": ["bool"], "R": ["bool"], "S": ["bool"], "T": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 4
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": [],
             "BEFORE": [
@@ -172,14 +186,14 @@ class ConstrainedChain(APattern):
 
 
 class Precedence(APattern):
+    group: str = "Order"
+    order: int = 4
+    old_names = ["Precedence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds then {S} previously held"
-        self.old_names = ["Precedence"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 4
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["⌈!S⌉;⌈R⌉;true"],
             "BEFORE": ["⌈(!P && !S)⌉;⌈(!P && R)⌉;true"],
@@ -190,16 +204,17 @@ class Precedence(APattern):
 
 
 class PrecedenceChain21(APattern):
+    group: str = "Order"
+    order: int = 5
+    old_names = ["PrecedenceChain2-1"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds then {S} previously held and was preceded by {T}"
         )
-        self.old_names = ["PrecedenceChain2-1"]
+
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 5
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["⌈!T⌉;⌈R⌉;true", "⌈!S⌉;⌈R⌉;true", "⌈!T⌉;⌈(S && !T)⌉;⌈!T⌉;⌈(!S && T)⌉;⌈!S⌉;⌈R⌉;true"],
             "BEFORE": [
@@ -226,16 +241,18 @@ class PrecedenceChain21(APattern):
 
 
 class PrecedenceChain12(APattern):
+    group: str = "Order"
+    order: int = 6
+    old_names = ["PrecedenceChain1-2"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds and is succeeded by {S}, then {T} previously held"
         )
-        self.old_names = ["PrecedenceChain1-2"]
+
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 6
+
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["⌈!T⌉;⌈R⌉;true;⌈S⌉;true"],
             "BEFORE": ["⌈(!P && !T)⌉;⌈(!P && R)⌉;⌈!P⌉;⌈(!P && S)⌉;true"],
@@ -246,14 +263,16 @@ class PrecedenceChain12(APattern):
 
 
 class Universality(APattern):
+    group: str = "Occurence"
+    order: int = 0
+    old_names = ["Universality"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that {R} holds"
-        self.old_names = ["Universality"]
+
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Occurence"
-        self.order: int = 0
+
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && !R)⌉;true"],
@@ -264,14 +283,14 @@ class Universality(APattern):
 
 
 class UniversalityDelay(APattern):
+    group: str = "Real-time"
+    order: int = 5
+    old_names = ["UniversalityDelay"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that {R} holds after at most {S} time units"
-        self.old_names = ["UniversalityDelay"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 5
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true ∧ ℓ ≥ S;⌈!R⌉;true"],
             "BEFORE": ["⌈!P⌉ ∧ ℓ ≥ S;⌈(!P && !R)⌉;true"],
@@ -282,14 +301,14 @@ class UniversalityDelay(APattern):
 
 
 class ExistenceBoundU(APattern):
+    group: str = "Occurence"
+    order: int = 3
+    old_names = ["BoundedExistence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "transitions to states in which {R} holds occur at most twice"
-        self.old_names = ["BoundedExistence"]
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Occurence"
-        self.order: int = 3
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉;⌈!R⌉;⌈R⌉;⌈!R⌉;⌈R⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉;⌈(!P && !R)⌉;⌈(!P && R)⌉;⌈(!P && !R)⌉;⌈(!P && R)⌉;true"],
@@ -302,14 +321,14 @@ class ExistenceBoundU(APattern):
 
 
 class Invariance(APattern):
+    group: str = "Occurence"
+    order: int = 2
+    old_names = ["Invariant"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds, then {S} holds as well"
-        self.old_names = ["Invariant"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"]}
-        self.group: str = "Occurence"
-        self.order: int = 2
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈(R && !S)⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && (R && !S))⌉;true"],
@@ -320,14 +339,14 @@ class Invariance(APattern):
 
 
 class Absence(APattern):
+    group: str = "Occurence"
+    order: int = 4
+    old_names = ["Absence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is never the case that {R} holds"
-        self.old_names = ["Absence"]
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Occurence"
-        self.order: int = 4
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉;true"],
@@ -338,14 +357,16 @@ class Absence(APattern):
 
 
 class ResponseDelay(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BoundedResponse"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds, then {S} holds after at most {T} time units"
-        self.old_names = ["BoundedResponse"]
+
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
+
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && (R && !S))⌉;⌈(!P && !S)⌉ ∧ ℓ > T;true"],
@@ -356,14 +377,14 @@ class ResponseDelay(APattern):
 
 
 class ReccurrenceBound(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BoundedRecurrence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that {R} holds at least every {S} time units"
-        self.old_names = ["BoundedRecurrence"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉ ∧ ℓ > S;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && !R)⌉ ∧ ℓ > S;true"],
@@ -374,16 +395,16 @@ class ReccurrenceBound(APattern):
 
 
 class DurationBoundU(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["MaxDuration"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that once {R} becomes satisfied, it holds for less than {S} time units"
         )
-        self.old_names = ["MaxDuration"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉ ∧ ℓ ≥ S;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉ ∧ ℓ ≥ S;true"],
@@ -394,16 +415,16 @@ class DurationBoundU(APattern):
 
 
 class ResponseBoundL12(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["TimeConstrainedMinDuration"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds for at least {S} time units, then {T} holds afterwards for at least {U} time units"
         )
-        self.old_names = ["TimeConstrainedMinDuration"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"], "T": ["bool"], "U": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉ ∧ ℓ ≥ S;⌈T⌉ ∧ ℓ <₀ U;⌈!T⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉ ∧ ℓ ≥ S;⌈(!P && T)⌉ ∧ ℓ <₀ U;⌈(!P && !T)⌉;true"],
@@ -414,14 +435,14 @@ class ResponseBoundL12(APattern):
 
 
 class InvarianceBoundL2(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BoundedInvariance"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds, then {S} holds for at least {T} time units"
-        self.old_names = ["BoundedInvariance"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉;true ∧ ℓ < T;⌈!S⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉;⌈!P⌉ ∧ ℓ < T;⌈(!P && !S)⌉;true"],
@@ -432,16 +453,16 @@ class InvarianceBoundL2(APattern):
 
 
 class ResponseBoundL1(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["TimeConstrainedInvariant"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds for at least {S} time units, then {T} holds afterwards"
         )
-        self.old_names = ["TimeConstrainedInvariant"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"], "T": ["bool"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉ ∧ ℓ ≥ S;⌈!T⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉ ∧ ℓ ≥ S;⌈(!P && !T)⌉;true"],
@@ -452,16 +473,16 @@ class ResponseBoundL1(APattern):
 
 
 class DurationBoundL(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["MinDuration"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that once {R} becomes satisfied, it holds for at least {S} time units"
         )
-        self.old_names = ["MinDuration"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉;⌈R⌉ ∧ ℓ < S;⌈!R⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && !R)⌉;⌈(!P && R)⌉ ∧ ℓ < S;⌈(!P && !R)⌉;true"],
@@ -472,16 +493,16 @@ class DurationBoundL(APattern):
 
 
 class ResponseDelayBoundL2(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["ConstrainedTimedExistence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds, then {S} holds after at most {T} time units for at least {U} time units"
         )
-        self.old_names = ["ConstrainedTimedExistence"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "U": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉;⌈!S⌉ ∧ ℓ > T;true", "true;⌈R⌉;⌈!S⌉ ∧ ℓ <₀ T;⌈S⌉ ∧ ℓ < U;⌈!S⌉;true"],
             "BEFORE": [
@@ -501,16 +522,16 @@ class ResponseDelayBoundL2(APattern):
 
 
 class TriggerResponseBoundL1(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BndTriggeredEntryConditionPattern"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that after {R} holds for at least {S} time units and {T} holds, then {U} holds"
         )
-        self.old_names = ["BndTriggeredEntryConditionPattern"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"], "T": ["bool"], "U": ["bool"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉ ∧ ℓ ≥ S;⌈(R && (T && !U))⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉ ∧ ℓ ≥ S;⌈(!P && (R && (T && !U)))⌉;true"],
@@ -521,16 +542,16 @@ class TriggerResponseBoundL1(APattern):
 
 
 class TriggerResponseDelayBoundL1(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BndTriggeredEntryConditionPatternDelayed"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that after {R} holds for at least {S}  time units and {T} holds, then {U} holds after at most {V}  time units"
         )
-        self.old_names = ["BndTriggeredEntryConditionPatternDelayed"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"], "T": ["bool"], "U": ["bool"], "V": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉ ∧ ℓ ≥ S;⌈(R && (T && !U))⌉;⌈!U⌉ ∧ ℓ > V;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉ ∧ ℓ ≥ S;⌈(!P && (R && (T && !U)))⌉;⌈(!P && !U)⌉ ∧ ℓ > V;true"],
@@ -543,16 +564,16 @@ class TriggerResponseDelayBoundL1(APattern):
 
 
 class EdgeResponseDelay(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["EdgeResponsePatternDelayed"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that once {R} becomes satisfied, {S} holds after at most {T} time units"
         )
-        self.old_names = ["EdgeResponsePatternDelayed"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && !R)⌉;⌈(!P && (R && !S))⌉;⌈(!P && !S)⌉ ∧ ℓ > T;true"],
@@ -563,16 +584,16 @@ class EdgeResponseDelay(APattern):
 
 
 class EdgeResponseBoundL2(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BndEdgeResponsePattern"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that once {R} becomes satisfied, {S} holds for at least {T} time units"
         )
-        self.old_names = ["BndEdgeResponsePattern"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉;⌈R⌉;⌈S⌉ ∧ ℓ < T;⌈!S⌉;true", "true;⌈!R⌉;⌈(R && !S)⌉;true"],
             "BEFORE": [
@@ -592,16 +613,16 @@ class EdgeResponseBoundL2(APattern):
 
 
 class EdgeResponseDelayBoundL2(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BndEdgeResponsePatternDelayed"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that once {R} becomes satisfied, {S} holds after at most {T} time units for at least {U} time units"
         )
-        self.old_names = ["BndEdgeResponsePatternDelayed"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"], "U": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true", "true;⌈!R⌉;⌈R⌉;true ∧ ℓ < T;⌈S⌉ ∧ ℓ < U;⌈!S⌉;true"],
             "BEFORE": [
@@ -624,16 +645,16 @@ class EdgeResponseDelayBoundL2(APattern):
 
 
 class EdgeResponseBoundU1(APattern):
+    group: str = "Real-time"
+    order: int = 0
+    old_names = ["BndEdgeResponsePatternTU "]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that once {R} becomes satisfied and holds for at most {S} time units, then {T} holds  afterwards"
         )
-        self.old_names = ["BndEdgeResponsePatternTU "]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"], "T": ["bool"]}
-        self.group: str = "Real-time"
-        self.order: int = 0
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈!R⌉;⌈R⌉ ∧ ℓ ≤ S;⌈(!R && !T)⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && !R)⌉;⌈(!P && R)⌉ ∧ ℓ ≥ S;⌈(!P && (!R && !T))⌉;true"],
@@ -644,14 +665,14 @@ class EdgeResponseBoundU1(APattern):
 
 
 class Initialization(APattern):
+    group: str = "Order"
+    order: int = 6
+    old_names = ["Initialization "]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that initially {R} holds"
-        self.old_names = ["Initialization "]
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 6
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["⌈!R⌉;true"],
             "BEFORE": ["⌈(!P && !R)⌉;true"],
@@ -662,14 +683,14 @@ class Initialization(APattern):
 
 
 class Persistence(APattern):
+    group: str = "Order"
+    order: int = 7
+    old_names = ["Persistence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds, then it holds persistently"
-        self.old_names = ["Persistence"]
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Order"
-        self.order: int = 7
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R⌉;⌈!R⌉;true"],
             "BEFORE": ["⌈!P⌉;⌈(!P && R)⌉;⌈(!P && !R)⌉;true"],
@@ -680,16 +701,16 @@ class Persistence(APattern):
 
 
 class ConditionalResponseBoundL1(APattern):
+    group: str = "Real-time"
+    order: int = 10
+    old_names = ["InvarianceDelay"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds, then {S} holds as well after at most {T} time units"
         )
-        self.old_names = ["InvarianceDelay"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["real"]}
-        self.group: str = "Real-time"
-        self.order: int = 10
         self._countertraces: dict[str, list[str]] = {
             "GLOBALLY": ["true;⌈R && S⌉;⌈R && !S⌉;true", "true;⌈R && !S⌉;⌈!S⌉ ∧ ℓ > T;true"],
             "BEFORE": [],
@@ -700,61 +721,61 @@ class ConditionalResponseBoundL1(APattern):
 
 
 class Toggle1(APattern):
+    group: str = "Legacy"
+    order: int = 0
+    old_names = ["Toggle1"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "it is always the case that if {R} holds then {S} toggles {T}"
-        self.old_names = ["Toggle1"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["bool"]}
-        self.group: str = "Legacy"
-        self.order: int = 0
 
 
 class Toggle2(APattern):
+    group: str = "Legacy"
+    order: int = 0
+    old_names = ["Toggle2"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds then {S} toggles {T} at most {U} time units later"
         )
-        self.old_names = ["Toggle2"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["bool"], "U": ["real"]}
-        self.group: str = "Legacy"
-        self.order: int = 0
 
 
 class BndEntryConditionPattern(APattern):
+    group: str = "Legacy"
+    order: int = 0
+    old_names = ["BndEntryConditionPattern"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that after {R} holds for at least {S}  time units, then {T} holds"
         )
-        self.old_names = ["BndEntryConditionPattern"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["real"], "T": ["bool"]}
-        self.group: str = "Legacy"
-        self.order: int = 0
 
 
 class ResponseChain21(APattern):
+    group: str = "Legacy"
+    order: int = 1
+    old_names = ["ResponseChain2-1"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = (
             "it is always the case that if {R} holds and is succeeded by {S}, then {T} eventually holds after {S}"
         )
-        self.old_names = ["ResponseChain2-1"]
         self._env: dict[str, list[str]] = {"R": ["bool"], "S": ["bool"], "T": ["bool"]}
-        self.group: str = "Legacy"
-        self.order: int = 1
 
 
 class Existence(APattern):
+    group: str = "Legacy"
+    order: int = 1
+    old_names = ["Existence"]
 
     def __init__(self):
         super().__init__()
         self._pattern_text: str = "{R} eventually holds"
-        self.old_names = ["Existence"]
         self._env: dict[str, list[str]] = {"R": ["bool"]}
-        self.group: str = "Legacy"
-        self.order: int = 1

--- a/hanfor/lib_core/startup.py
+++ b/hanfor/lib_core/startup.py
@@ -40,7 +40,7 @@ def config_check(app_config):
             raise SyntaxError(f"Could not find {to_ensure_config} in config.")
 
     # Check pattern groups set correctly.
-    pattern_groups_used = set((pattern.group for pattern in APattern().get_patterns().values()))
+    pattern_groups_used = set((pattern.group for pattern in APattern.get_patterns().values()))
     pattern_groups_set = set((group for group in app_config["PATTERNS_GROUP_ORDER"]))
     # Pattern group for downwards compatibility: Legacy patterns are not shown in dropdown (but still deserializable)
     pattern_groups_set.add("Legacy")

--- a/hanfor/lib_core/utils.py
+++ b/hanfor/lib_core/utils.py
@@ -64,8 +64,8 @@ def get_default_pattern_options():
     opt_group_lists = defaultdict(list)
     opt_groups = defaultdict(str)
     # Collect pattern in groups.
-    for name, pattern in APattern().get_patterns().items():
-        opt_group_lists[pattern.group].append((pattern.order, name, pattern._pattern_text))
+    for name, pattern in APattern.get_patterns().items():
+        opt_group_lists[pattern.group].append((pattern.order, name, pattern()._pattern_text))
 
     # Sort groups and concatenate pattern options
     for group_name, opt_list in opt_group_lists.items():

--- a/hanfor/lib_pea/boogie_pysmt_transformer.py
+++ b/hanfor/lib_pea/boogie_pysmt_transformer.py
@@ -1,33 +1,8 @@
 from dataclasses import dataclass
 
 from lark import Transformer, Token
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import (
-    And,
-    Or,
-    Div,
-    FALSE,
-    TRUE,
-    GT,
-    GE,
-    Symbol,
-    Implies,
-    LT,
-    LE,
-    Minus,
-    Not,
-    NotEquals,
-    Int,
-    Plus,
-    Real,
-    Times,
-    EqualsOrIff,
-    Max,
-    Min,
-    Ite,
-    Iff,
-)
-from pysmt.typing import INT, BOOL, REAL
 
 
 @dataclass
@@ -38,138 +13,119 @@ class Variable:
 
 
 class BoogiePysmtTransformer(Transformer):
-    hanfor_to_pysmt_mapping = {
-        "bool": lambda name, value: Symbol(name, BOOL),
-        "int": lambda name, value: Symbol(name, INT),
-        "real": lambda name, value: Symbol(name, REAL),
-        "ENUM_INT": lambda name, value: Symbol(name, INT),
-        "ENUM_REAL": lambda name, value: Symbol(name, REAL),
-        "ENUMERATOR_INT": lambda name, value: Int(int(value)),
-        "ENUMERATOR_REAL": lambda name, value: Real(float(value)),
-        # TODO: Make this better, please.
-        "CONST": lambda name, value: Real(float(value)) if "." in value else Int(int(value)),
-    }
 
-    def __init__(self, variables: set[Variable]) -> None:
+    def __init__(self, smt_env: Environment, variables: set[Variable]) -> None:
         super().__init__()
         self.variables = variables
         self.additional_assertions = []
+        self.__smt_env = smt_env
+        self.__fmgr = self.__smt_env.formula_manager
+        self.__tmgr = self.__smt_env.type_manager
+
+        hanfor_to_pysmt_mapping = {
+            "bool": lambda name, value: self.__fmgr.Symbol(name, self.__tmgr.BOOL()),
+            "int": lambda name, value: self.__fmgr.Symbol(name, self.__tmgr.INT()),
+            "real": lambda name, value: self.__fmgr.Symbol(name, self.__tmgr.REAL()),
+            "ENUM_INT": lambda name, value: self.__fmgr.Symbol(name, self.__tmgr.INT()),
+            "ENUM_REAL": lambda name, value: self.__fmgr.Symbol(name, self.__tmgr.REAL()),
+            "ENUMERATOR_INT": lambda name, value: self.__fmgr.Int(int(value)),
+            "ENUMERATOR_REAL": lambda name, value: self.__fmgr.Real(float(value)),
+            # TODO: Make this better, please.
+            "CONST": lambda name, value: (
+                self.__fmgr.Real(float(value)) if "." in value else self.__fmgr.Int(int(value))
+            ),
+        }
         self.smt_symbols = dict()
         self.smt_vars = dict()
         for v in variables:
-            sym = self.hanfor_to_pysmt_mapping[v.type](v.name, v.value)
+            sym = hanfor_to_pysmt_mapping[v.type](v.name, v.value)
             self.smt_symbols[v.name] = sym
             if sym.is_symbol():
-                self.smt_vars[v.name] = self.hanfor_to_pysmt_mapping[v.type](v.name, v.value)
+                self.smt_vars[v.name] = hanfor_to_pysmt_mapping[v.type](v.name, v.value)
 
     def expr(self, children) -> FNode:
-        return And(children[0], *self.additional_assertions)
+        return self.__fmgr.And(children[0], *self.additional_assertions)
 
-    @staticmethod
-    def conjunction(children) -> FNode:
-        return And(children[0], children[2])
+    def conjunction(self, children) -> FNode:
+        return self.__fmgr.And(children[0], children[2])
 
-    @staticmethod
-    def disjunction(children) -> FNode:
-        return Or(children[0], children[2])
+    def disjunction(self, children) -> FNode:
+        return self.__fmgr.Or(children[0], children[2])
 
-    @staticmethod
-    def divide(children) -> FNode:
-        return Div(children[0], children[2])
+    def divide(self, children) -> FNode:
+        return self.__fmgr.Div(children[0], children[2])
 
-    @staticmethod
-    def eq(children) -> FNode:
-        return EqualsOrIff(children[0], children[2])
+    def eq(self, children) -> FNode:
+        return self.__fmgr.EqualsOrIff(children[0], children[2])
 
-    @staticmethod
-    def false(children) -> FNode:
-        return FALSE()
+    def false(self, children) -> FNode:
+        return self.__fmgr.FALSE()
 
-    @staticmethod
-    def gt(children) -> FNode:
-        return GT(children[0], children[2])
+    def gt(self, children) -> FNode:
+        return self.__fmgr.GT(children[0], children[2])
 
-    @staticmethod
-    def gteq(children) -> FNode:
-        return GE(children[0], children[2])
+    def gteq(self, children) -> FNode:
+        return self.__fmgr.GE(children[0], children[2])
 
     def id(self, children) -> FNode:
         name = children[0].value
         return self.smt_symbols[name]
 
-    @staticmethod
-    def implies(children) -> FNode:
-        return Implies(children[0], children[2])
+    def implies(self, children) -> FNode:
+        return self.__fmgr.Implies(children[0], children[2])
 
-    @staticmethod
-    def explies(children) -> FNode:
-        return Implies(children[2], children[0])
+    def explies(self, children) -> FNode:
+        return self.__fmgr.Implies(children[2], children[0])
 
-    @staticmethod
-    def iff(children) -> FNode:
-        return Iff(children[0], children[2])
+    def iff(self, children) -> FNode:
+        return self.__fmgr.Iff(children[0], children[2])
 
-    @staticmethod
-    def lt(children) -> FNode:
-        return LT(children[0], children[2])
+    def lt(self, children) -> FNode:
+        return self.__fmgr.LT(children[0], children[2])
 
-    @staticmethod
-    def lteq(children) -> FNode:
-        return LE(children[0], children[2])
+    def lteq(self, children) -> FNode:
+        return self.__fmgr.LE(children[0], children[2])
 
-    @staticmethod
-    def minus(children) -> FNode:
-        return Minus(children[0], children[2])
+    def minus(self, children) -> FNode:
+        return self.__fmgr.Minus(children[0], children[2])
 
-    @staticmethod
-    def minus_unary(children) -> FNode:
-        return -children[1]
+    def minus_unary(self, children) -> FNode:
+        return self.__fmgr.Times(self.__fmgr.Int(-1), children[1])
 
-    # @staticmethod
     def mod(self, children) -> None:
         D, d = children[0], children[2]
-        self.additional_assertions.append(NotEquals(d, Int(0)))
-        return Minus(D, Times(d, Div(D, d)))
+        self.additional_assertions.append(self.__fmgr.NotEquals(d, self.__fmgr.Int(0)))
+        return self.__fmgr.Minus(D, self.__fmgr.Times(d, self.__fmgr.Div(D, d)))
 
-    @staticmethod
-    def negation(children) -> FNode:
-        return Not(children[1])
+    def negation(self, children) -> FNode:
+        return self.__fmgr.Not(children[1])
 
-    @staticmethod
-    def neq(children) -> FNode:
-        return NotEquals(children[0], children[2])
+    def neq(self, children) -> FNode:
+        return self.__fmgr.NotEquals(children[0], children[2])
 
-    @staticmethod
-    def number(children) -> FNode:
-        return Int(int(children[0]))
+    def number(self, children) -> FNode:
+        return self.__fmgr.Int(int(children[0]))
 
-    @staticmethod
-    def plus(children) -> FNode:
-        return Plus(children[0], children[2])
+    def plus(self, children) -> FNode:
+        return self.__fmgr.Plus(children[0], children[2])
 
-    @staticmethod
-    def realnumber(children) -> FNode:
-        return Real(float(children[0]))
+    def realnumber(self, children) -> FNode:
+        return self.__fmgr.Real(float(children[0]))
 
-    @staticmethod
-    def times(children) -> FNode:
-        return Times(children[0], children[2])
+    def times(self, children) -> FNode:
+        return self.__fmgr.Times(children[0], children[2])
 
-    @staticmethod
-    def true(children) -> FNode:
-        return TRUE()
+    def true(self, children) -> FNode:
+        return self.__fmgr.TRUE()
 
-    @staticmethod
-    def abs(children) -> FNode:
-        return Ite(children[1] < 0, -children[1], children[1])
+    def abs(self, children) -> FNode:
+        return self.__fmgr.Ite(children[1] < 0, -children[1], children[1])
 
-    @staticmethod
-    def min(children) -> FNode:
-        return Min(children[1], children[2])
+    def min(self, children) -> FNode:
+        return self.__fmgr.Min(children[1], children[2])
 
-    @staticmethod
-    def max(children) -> FNode:
-        return Max(children[1], children[2])
+    def max(self, children) -> FNode:
+        return self.__fmgr.Max(children[1], children[2])
 
     @staticmethod
     def old(children) -> FNode:

--- a/hanfor/lib_pea/countertrace.py
+++ b/hanfor/lib_pea/countertrace.py
@@ -2,21 +2,21 @@ from enum import Enum
 from typing import Union
 
 from lark.visitors import Transformer
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.formula import FormulaManager
-from pysmt.shortcuts import TRUE, Not, And, Or, get_free_variables
 
 
 class Countertrace:
-    def __init__(self, *dc_phases: "DCPhase") -> None:
-        self.dc_phases: list[Countertrace.DCPhase] = [dc_phase for dc_phase in dc_phases]
+    def __init__(self, smt_env: Environment, *dc_phases: "DCPhase") -> None:
+        self.__smt_env: Environment = smt_env
+        self.dc_phases: list["DCPhase"] = [dc_phase for dc_phase in dc_phases]
 
     def __str__(self) -> str:
         return ";".join([str(dc_phase) for dc_phase in self.dc_phases])
 
-    def normalize(self, formula_manager: FormulaManager) -> None:
+    def normalize(self) -> None:
         for dc_phase in self.dc_phases:
-            dc_phase.normalize(formula_manager)
+            dc_phase.normalize()
 
     def extract_variables(self) -> frozenset[FNode]:
         variables = set()
@@ -26,42 +26,46 @@ class Countertrace:
 
         return frozenset(variables)
 
-    class BoundTypes(Enum):
-        NONE = 0
-        LESS = 1
-        LESSEQUAL = 2
-        GREATER = 3
-        GREATEREQUAL = 4
 
-        def invert(self):
-            match self:
-                case Countertrace.BoundTypes.LESS:
-                    return Countertrace.BoundTypes.GREATEREQUAL
-                case Countertrace.BoundTypes.LESSEQUAL:
-                    return Countertrace.BoundTypes.GREATER
-                case Countertrace.BoundTypes.GREATER:
-                    return Countertrace.BoundTypes.LESSEQUAL
-                case Countertrace.BoundTypes.GREATEREQUAL:
-                    return Countertrace.BoundTypes.LESS
-                case _:
-                    return Countertrace.BoundTypes.NONE
+class BoundTypes(Enum):
+    NONE = 0
+    LESS = 1
+    LESSEQUAL = 2
+    GREATER = 3
+    GREATEREQUAL = 4
+
+    def invert(self):
+        match self:
+            case BoundTypes.LESS:
+                return BoundTypes.GREATEREQUAL
+            case BoundTypes.LESSEQUAL:
+                return BoundTypes.GREATER
+            case BoundTypes.GREATER:
+                return BoundTypes.LESSEQUAL
+            case BoundTypes.GREATEREQUAL:
+                return BoundTypes.LESS
+            case _:
+                return BoundTypes.NONE
 
 
 class DCPhase:
     def __init__(
         self,
+        smt_env: Environment,
         entry_events: FNode,
         invariant: FNode,
-        bound_type: "Countertrace.BoundTypes",
-        bound: Union[FNode, None],
+        bound_type: "BoundTypes",
+        bound: Union[FNode, float, None],
         forbid: set[str],
         allow_empty: bool,
     ) -> None:
+        self.__smt_env = smt_env
+        self.__fmgr = smt_env.formula_manager
         self.entry_events: FNode = entry_events
         self.invariant: FNode = invariant
-        self.bound_type: Countertrace.BoundTypes = bound_type
+        self.bound_type: BoundTypes = bound_type
         # TODO: typing for this bound field is all over the place (sometimes None, Int or FNode) fix that
-        self.bound: Union[FNode, None] = bound
+        self.bound: Union[FNode, float, None] = bound
         self.forbid: set[str] = forbid
         self.allow_empty: bool = allow_empty
 
@@ -77,26 +81,28 @@ class DCPhase:
         _RCEIL = "\u2309" if unicode else "]"
         _ELL = "\u2113" if unicode else "L"
 
-        result += self.entry_events.serialize() + ";" if self.entry_events != TRUE() else ""
+        result += self.entry_events.serialize() + ";" if self.entry_events != self.__fmgr.TRUE() else ""
         result += (
-            self.invariant.serialize() if self.invariant == TRUE() else _LCEIL + self.invariant.serialize() + _RCEIL
+            self.invariant.serialize()
+            if self.invariant == self.__fmgr.TRUE()
+            else _LCEIL + self.invariant.serialize() + _RCEIL
         )
 
         for forbid in self.forbid:
             result += " " + _AND + " " + _NO_EVENT + " " + forbid
 
-        if self.bound_type == Countertrace.BoundTypes.NONE:
+        if self.bound_type == BoundTypes.NONE:
             return result
 
         result += " " + _AND + " " + _ELL
 
-        if self.bound_type == Countertrace.BoundTypes.LESS:
+        if self.bound_type == BoundTypes.LESS:
             result += " <" + _EMPTY + " " if self.allow_empty else " < "
-        elif self.bound_type == Countertrace.BoundTypes.LESSEQUAL:
+        elif self.bound_type == BoundTypes.LESSEQUAL:
             result += " " + _LEQ + _EMPTY + " " if self.allow_empty else " " + _LEQ + " "
-        elif self.bound_type == Countertrace.BoundTypes.GREATER:
+        elif self.bound_type == BoundTypes.GREATER:
             result += " >" + _EMPTY + " " if self.allow_empty else " > "
-        elif self.bound_type == Countertrace.BoundTypes.GREATEREQUAL:
+        elif self.bound_type == BoundTypes.GREATEREQUAL:
             result += " " + _GEQ + _EMPTY + " " if self.allow_empty else " " + _GEQ + " "
         else:
             raise ValueError("Unexpected value of `bound_type`: %s" % self.bound_type)
@@ -105,99 +111,89 @@ class DCPhase:
 
         return result
 
-    def normalize(self, formula_manager: FormulaManager) -> None:
-        if self.entry_events is not None and self.entry_events not in formula_manager:
-            formula_manager.normalize(self.entry_events)
+    def normalize(self) -> None:
+        if self.entry_events is not None and self.entry_events not in self.__fmgr:
+            self.__fmgr.normalize(self.entry_events)
 
-        if self.invariant is not None and self.invariant not in formula_manager:
-            formula_manager.normalize(self.invariant)
+        if self.invariant is not None and self.invariant not in self.__fmgr:
+            self.__fmgr.normalize(self.invariant)
 
     def is_upper_bound(self) -> bool:
-        return self.bound_type == Countertrace.BoundTypes.LESS or self.bound_type == Countertrace.BoundTypes.LESSEQUAL
+        return self.bound_type == BoundTypes.LESS or self.bound_type == BoundTypes.LESSEQUAL
 
     def is_lower_bound(self) -> bool:
-        return (
-            self.bound_type == Countertrace.BoundTypes.GREATER
-            or self.bound_type == Countertrace.BoundTypes.GREATEREQUAL
-        )
+        return self.bound_type == BoundTypes.GREATER or self.bound_type == BoundTypes.GREATEREQUAL
 
     def extract_variables(self) -> set[FNode]:
-        return set(get_free_variables(self.invariant))
+        return set(self.__smt_env.fvo.get_free_variables(self.invariant))
 
 
-def phaseT() -> DCPhase:
-    return DCPhase(TRUE(), TRUE(), Countertrace.BoundTypes.NONE, None, set(), True)
+def phaseT(smt_env: Environment) -> DCPhase:
+    return DCPhase(
+        smt_env, smt_env.formula_manager.TRUE(), smt_env.formula_manager.TRUE(), BoundTypes.NONE, None, set(), True
+    )
 
 
-def phaseE(invariant: FNode, bound_type: Countertrace.BoundTypes, bound: int) -> DCPhase:
-    return DCPhase(TRUE(), invariant, bound_type, bound, set(), True)
+def phaseE(smt_env: Environment, invariant: FNode, bound_type: BoundTypes, bound: int) -> DCPhase:
+    return DCPhase(smt_env, smt_env.formula_manager.TRUE(), invariant, bound_type, bound, set(), True)
 
 
-def phase(
-    invariant: FNode, bound_type: Countertrace.BoundTypes = Countertrace.BoundTypes.NONE, bound: int = 0
-) -> DCPhase:
-    return DCPhase(TRUE(), invariant, bound_type, bound, set(), False)
+def phase(smt_env: Environment, invariant: FNode, bound_type: BoundTypes = BoundTypes.NONE, bound: int = 0) -> DCPhase:
+    return DCPhase(smt_env, smt_env.formula_manager.TRUE(), invariant, bound_type, bound, set(), False)
 
 
 class CountertraceTransformer(Transformer):
-    def __init__(self, expressions: dict[str, FNode]) -> None:
+    def __init__(self, smt_env: Environment, expressions: dict[str, FNode]) -> None:
         super().__init__()
         self.expressions = expressions
+        self.__smt_env = smt_env
+        self.__fmgr = smt_env.formula_manager
+
+    def countertrace(self, children) -> Countertrace:
+        return Countertrace(self.__smt_env, *children)
+
+    def phase_t(self, children) -> DCPhase:
+        return phaseT(self.__smt_env)
+
+    def phase_unbounded(self, children) -> DCPhase:
+        return phase(self.__smt_env, children[0])
+
+    def phase(self, children) -> DCPhase:
+        return phase(self.__smt_env, children[0], children[1], children[2])
+
+    def phase_e(self, children) -> DCPhase:
+        return phaseE(self.__smt_env, children[0], children[1], children[2])
+
+    def conjunction(self, children) -> DCPhase:
+        return self.__fmgr.And(children[0], children[1])
+
+    def disjunction(self, children) -> DCPhase:
+        return self.__fmgr.Or(children[0], children[1])
+
+    def negation(self, children) -> DCPhase:
+        return self.__fmgr.Not(children[0])
 
     @staticmethod
-    def countertrace(children) -> Countertrace:
-        return Countertrace(*children)
+    def bound_type_lt(children) -> BoundTypes:
+        return BoundTypes.LESS
 
     @staticmethod
-    def phase_t(children) -> DCPhase:
-        return phaseT()
+    def bound_type_lteq(children) -> BoundTypes:
+        return BoundTypes.LESSEQUAL
 
     @staticmethod
-    def phase_unbounded(children) -> DCPhase:
-        return phase(children[0])
+    def bound_type_gt(children) -> BoundTypes:
+        return BoundTypes.GREATER
 
     @staticmethod
-    def phase(children) -> DCPhase:
-        return phase(children[0], children[1], children[2])
-
-    @staticmethod
-    def phase_e(children) -> DCPhase:
-        return phaseE(children[0], children[1], children[2])
-
-    @staticmethod
-    def conjunction(children) -> DCPhase:
-        return And(children[0], children[1])
-
-    @staticmethod
-    def disjunction(children) -> DCPhase:
-        return Or(children[0], children[1])
-
-    @staticmethod
-    def negation(children) -> DCPhase:
-        return Not(children[0])
-
-    @staticmethod
-    def bound_type_lt(children) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.LESS
-
-    @staticmethod
-    def bound_type_lteq(children) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.LESSEQUAL
-
-    @staticmethod
-    def bound_type_gt(children) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.GREATER
-
-    @staticmethod
-    def bound_type_gteq(children) -> Countertrace.BoundTypes:
-        return Countertrace.BoundTypes.GREATEREQUAL
+    def bound_type_gteq(children) -> BoundTypes:
+        return BoundTypes.GREATEREQUAL
 
     def variable(self, children) -> FNode:
         return self.expressions.get(children[0])
 
-    @staticmethod
-    def true(children) -> FNode:
-        return TRUE()
+    def true(self, children) -> FNode:
+        return self.__fmgr.TRUE()
 
     @staticmethod
     def __default__(data, children, meta):

--- a/hanfor/lib_pea/countertrace_to_pea.py
+++ b/hanfor/lib_pea/countertrace_to_pea.py
@@ -1,82 +1,92 @@
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import TRUE, And, FALSE, Or, Not, Symbol, LT, GE, LE, is_sat, Solver, is_valid, Iff
-from pysmt.typing import REAL
 from z3 import Then, Tactic, With
 
-from lib_pea.countertrace import Countertrace
-from lib_pea.pea import PhaseSetsPea, Pea
-from lib_pea.transition import PhaseSetsTransition
+from lib_pea.countertrace import Countertrace, BoundTypes
 from lib_pea.location import PhaseSetsLocation
+from lib_pea.pea import PhaseSetsPea
 from lib_pea.phase_sets import PhaseSets
-from lib_pea.config import SOLVER_NAME, LOGIC
+from lib_pea.transition import PhaseSetsTransition
 from lib_pea.utils import substitute_free_variables
 
-solver_z3 = Solver(name="z3")
 
+class PeaBuilder:
 
-def build_automaton(ct: Countertrace, cp: str = "c") -> PhaseSetsPea:
-    pea = PhaseSetsPea(ct)
-    visited, pending = set(), set()
-    init = True
+    def __init__(self, smt_env: Environment):
+        self.__smt_env = smt_env
+        self.__fmgr = self.__smt_env.formula_manager
+        self.__tmgr = self.__smt_env.type_manager
+        self.__solver = self.__smt_env.factory.Solver(name="z3")
 
-    while pending or init:
-        if init:
-            p = PhaseSets()
-            src = None
-        else:
-            p = pending.pop()
-            visited.add(p)
-            src = PhaseSetsLocation(compute_state_invariant(ct, p), compute_clock_invariant(ct, p, cp), p)
+    def build_automaton(self, ct: Countertrace, cp: str = "c") -> PhaseSetsPea:
+        pea = PhaseSetsPea(self.__smt_env, ct)
+        visited, pending = set(), set()
+        init = True
 
-        enter, keep = compute_enter_keep(ct, p, init, cp)
-        successors = build_successors(0, p, PhaseSets(), set(), TRUE(), ct, enter, keep, cp)
+        while pending or init:
+            if init:
+                p = PhaseSets()
+                src = None
+            else:
+                p = pending.pop()
+                visited.add(p)
+                src = PhaseSetsLocation(
+                    self.__smt_env, self.compute_state_invariant(ct, p), self.compute_clock_invariant(ct, p, cp), p
+                )
 
-        for s in successors:
-            dst = PhaseSetsLocation(compute_state_invariant(ct, s[0]), compute_clock_invariant(ct, s[0], cp), s[0])
+            enter, keep = self.compute_enter_keep(ct, p, init, cp)
+            successors = self.build_successors(0, p, PhaseSets(), set(), self.__fmgr.TRUE(), ct, enter, keep, cp)
 
-            if s[0] not in visited.union(pending):
-                pending.add(s[0])
+            for s in successors:
+                dst = PhaseSetsLocation(
+                    self.__smt_env,
+                    self.compute_state_invariant(ct, s[0]),
+                    self.compute_clock_invariant(ct, s[0], cp),
+                    s[0],
+                )
 
-            pea.add_transition(PhaseSetsTransition(src, dst, s[1], frozenset(s[2])))
+                if s[0] not in visited.union(pending):
+                    pending.add(s[0])
 
-        init = False
+                pea.add_transition(PhaseSetsTransition(self.__smt_env, src, dst, s[1], frozenset(s[2])))
 
-    return pea
+            init = False
 
+        return pea
 
-def compute_state_invariant(ct: Countertrace, p: PhaseSets) -> FNode:
-    inactive = {*range(len(ct.dc_phases))} - p.active
+    def compute_state_invariant(self, ct: Countertrace, p: PhaseSets) -> FNode:
+        inactive = {*range(len(ct.dc_phases))} - p.active
 
-    result = And(
-        *[ct.dc_phases[i].invariant for i in p.active],
-        *[Not(ct.dc_phases[i].invariant) for i in inactive if can_seep(p, i) == TRUE()],
-    )
-    return result
+        result = self.__fmgr.And(
+            *[ct.dc_phases[i].invariant for i in p.active],
+            *[
+                self.__fmgr.Not(ct.dc_phases[i].invariant)
+                for i in inactive
+                if self.can_seep(p, i) == self.__fmgr.TRUE()
+            ],
+        )
+        return result
 
+    def compute_clock_invariant(self, ct: Countertrace, p: PhaseSets, cp: str) -> FNode:
+        result = []
 
-def compute_clock_invariant(ct: Countertrace, p: PhaseSets, cp: str) -> FNode:
-    result = []
+        # TODO: check this
+        for i in p.active:
+            lt_args = [self.__fmgr.Symbol(cp + str(i), self.__tmgr.REAL()), ct.dc_phases[i].bound]
 
-    # TODO: check this
-    for i in p.active:
-        lt_args = [Symbol(cp + str(i), REAL), ct.dc_phases[i].bound]
+            if (i in p.wait) and (i in p.gteq and i == len(ct.dc_phases) - 2):
+                result.append(self.__fmgr.LT(*lt_args))
 
-        if (i in p.wait) and (i in p.gteq and i == len(ct.dc_phases) - 2):
-            result.append(LT(*lt_args))
+            if (i in p.wait) and not (i in p.gteq and i == len(ct.dc_phases) - 2):
+                result.append(self.__fmgr.LE(*lt_args))
 
-        if (i in p.wait) and not (i in p.gteq and i == len(ct.dc_phases) - 2):
-            result.append(LE(*lt_args))
+            if not (i in p.wait) and (ct.dc_phases[i].is_upper_bound() and self.can_seep(p, i) == self.__fmgr.FALSE()):
+                result.append(self.__fmgr.LE(*lt_args))
 
-        if not (i in p.wait) and (ct.dc_phases[i].is_upper_bound() and can_seep(p, i) == FALSE()):
-            result.append(LE(*lt_args))
+        return self.__fmgr.And(result)
 
-    # result = And(LE(Symbol(cp + str(i), REAL), ct.dc_phases[i].bound) for i in p.active if
-    #             i in p.wait or ct.dc_phases[i].is_upper_bound() and can_seep(p, i) == FALSE())
-
-    return And(result)
-
-
-def build_successors(
+    def build_successors(
+        self,
         i: int,
         p: PhaseSets,
         p_: PhaseSets,
@@ -86,270 +96,301 @@ def build_successors(
         enter: dict[int, FNode],
         keep: dict[int, FNode],
         cp: str,
-) -> list[tuple[PhaseSets, FNode, set[str]]]:
-    result = []
-    guard = simplify_with_z3(guard)
+    ) -> list[tuple[PhaseSets, FNode, set[str]]]:
+        result = []
+        guard = self.simplify_with_z3(guard)
 
-    # Terminate if guard is unsatisfiable.
-    if guard != TRUE() and (guard == FALSE() or not is_sat(guard, solver_name=SOLVER_NAME, logic=LOGIC)):
-        return []
+        # Terminate if guard is unsatisfiable.
+        if guard != self.__fmgr.TRUE() and (guard == self.__fmgr.FALSE() or not self.__solver.is_sat(guard)):
+            return []
 
-    # Check if successor and guard are complete.
-    if i >= len(ct.dc_phases):
-        # Add successor if last phase is not included.
-        if i - 1 not in p_.active:
-            return [(p_, guard, resets)]
+        # Check if successor and guard are complete.
+        if i >= len(ct.dc_phases):
+            # Add successor if last phase is not included.
+            if i - 1 not in p_.active:
+                return [(p_, guard, resets)]
 
-        return []
+            return []
 
-    # TODO: Primed vars are not needed.
-    # inv = substitute_free_variables(ct.dc_phases[i].invariant)
-    seep = And(can_seep(p_, i), ct.dc_phases[i].invariant)
+        # TODO: Primed vars are not needed.
+        # inv = substitute_free_variables(ct.dc_phases[i].invariant)
+        seep = self.__fmgr.And(self.can_seep(p_, i), ct.dc_phases[i].invariant)
 
-    # Case 1: i not in p_.active
-    result.extend(
-        build_successors(i + 1, p, p_, resets, And(guard, Not(Or(enter[i], keep[i], seep))), ct, enter, keep, cp)
-    )
-
-    # Case 2: i in p_.active
-    guard = And(guard, Or(enter[i], keep[i], seep))
-
-    if ct.dc_phases[i].is_lower_bound():
-        # Case 2a: clock i in resets
-        if ct.dc_phases[i].bound_type == Countertrace.BoundTypes.GREATEREQUAL:
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_gteq(i),
-                    resets.union({cp + str(i)}),
-                    And(guard, Not(keep[i]), enter[i]),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
+        # Case 1: i not in p_.active
+        result.extend(
+            self.build_successors(
+                i + 1,
+                p,
+                p_,
+                resets,
+                self.__fmgr.And(guard, self.__fmgr.Not(self.__fmgr.Or(enter[i], keep[i], seep))),
+                ct,
+                enter,
+                keep,
+                cp,
             )
+        )
 
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_wait(i),
-                    resets.union({cp + str(i)}),
-                    And(guard, Not(keep[i]), Not(enter[i])),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
+        # Case 2: i in p_.active
+        guard = self.__fmgr.And(guard, self.__fmgr.Or(enter[i], keep[i], seep))
+
+        if ct.dc_phases[i].is_lower_bound():
+            # Case 2a: clock i in resets
+            if ct.dc_phases[i].bound_type == BoundTypes.GREATEREQUAL:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_gteq(i),
+                        resets.union({cp + str(i)}),
+                        self.__fmgr.And(guard, self.__fmgr.Not(keep[i]), enter[i]),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
                 )
-            )
+
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_wait(i),
+                        resets.union({cp + str(i)}),
+                        self.__fmgr.And(guard, self.__fmgr.Not(keep[i]), self.__fmgr.Not(enter[i])),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+            else:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_wait(i),
+                        resets.union({cp + str(i)}),
+                        self.__fmgr.And(guard, self.__fmgr.Not(keep[i])),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+
+            # Case 2b: clock i not in resets
+            if i in p.wait:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_gteq(i) if i in p.gteq else p_.add_wait(i),
+                        resets,
+                        self.__fmgr.And(
+                            guard,
+                            keep[i],
+                            self.__fmgr.LT(self.__fmgr.Symbol(cp + str(i), self.__tmgr.REAL()), ct.dc_phases[i].bound),
+                        ),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_active(i),
+                        resets,
+                        self.__fmgr.And(
+                            guard,
+                            keep[i],
+                            self.__fmgr.GE(self.__fmgr.Symbol(cp + str(i), self.__tmgr.REAL()), ct.dc_phases[i].bound),
+                        ),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+            else:
+                result.extend(
+                    self.build_successors(
+                        i + 1, p, p_.add_active(i), resets, self.__fmgr.And(guard, keep[i]), ct, enter, keep, cp
+                    )
+                )
+
+        elif ct.dc_phases[i].is_upper_bound() and self.can_seep(p_, i) == self.__fmgr.FALSE():
+            # Case 2c: clock i in resets
+            if ct.dc_phases[i].bound_type == BoundTypes.LESS:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_less(i),
+                        resets.union({cp + str(i)}),
+                        self.__fmgr.And(guard, enter[i] or self.can_seep(p, i)),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+            else:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_less(i),
+                        resets.union({cp + str(i)}),
+                        self.__fmgr.And(guard, self.__fmgr.Not(enter[i]), self.can_seep(p, i)),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_active(i),
+                        resets.union({cp + str(i)}),
+                        self.__fmgr.And(guard, enter[i]),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+
+            # Case 2e: clock i not in resets
+            if i in p.less:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_less(i),
+                        resets,
+                        self.__fmgr.And(guard, self.__fmgr.Not(enter[i]), self.__fmgr.Not(self.can_seep(p, i))),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+            else:
+                result.extend(
+                    self.build_successors(
+                        i + 1,
+                        p,
+                        p_.add_active(i),
+                        resets,
+                        self.__fmgr.And(guard, self.__fmgr.Not(enter[i]), self.__fmgr.Not(self.can_seep(p, i))),
+                        ct,
+                        enter,
+                        keep,
+                        cp,
+                    )
+                )
+
         else:
-            result.extend(
-                build_successors(
-                    i + 1, p, p_.add_wait(i), resets.union({cp + str(i)}), And(guard, Not(keep[i])), ct, enter, keep, cp
+            # i in p_.active
+            result.extend(self.build_successors(i + 1, p, p_.add_active(i), resets, guard, ct, enter, keep, cp))
+
+        return result
+
+    def compute_enter_keep(
+        self, ct: Countertrace, p: PhaseSets, init: bool, cp: str
+    ) -> tuple[dict[int, FNode], dict[int, FNode]]:
+        enter_, keep_ = {}, {}
+
+        if init:
+            for i in range(-1, len(ct.dc_phases)):
+                inv = substitute_free_variables(self.__smt_env, ct.dc_phases[i].invariant)
+                enter_[i] = (
+                    self.__fmgr.TRUE()
+                    if i < 0
+                    else self.__fmgr.And(
+                        enter_[i - 1],
+                        self.__fmgr.TRUE() if ct.dc_phases[i - 1].allow_empty else self.__fmgr.FALSE(),
+                        inv,
+                    )
                 )
-            )
+                # enter_[i] = TRUE() if i < 0 else And(
+                #   enter_[i - 1],
+                #   TRUE() if ct.dc_phases[i - 1].allow_empty else FALSE(),
+                #   ct.dc_phases[i].invariant)
+                keep_[i] = self.__fmgr.FALSE()
+        else:
+            for i in range(len(ct.dc_phases)):
+                enter_[i] = self.enter(ct, p, i, cp)
+                keep_[i] = self.keep(ct, p, i, cp)
 
-            # result.extend(build_successors(i + 1, p, p_.add_wait(i), resets.union({cp + str(i)}),
-            #                                And(guard, Not(keep[i])), ct, enter, keep))
+        return enter_, keep_
 
-        # Case 2b: clock i not in resets
+    def enter(self, ct: Countertrace, p: PhaseSets, i: int, cp: str) -> FNode:
+        inv = substitute_free_variables(self.__smt_env, ct.dc_phases[i].invariant)
+        return self.__fmgr.And(
+            self.complete(ct, p, i - 1, cp), inv
+        )  # return And(complete(ct, p, i - 1), ct.dc_phases[i].invariant)
+
+    def seep(self, ct: Countertrace, p: PhaseSets, i: int) -> FNode:
+        inv = substitute_free_variables(self.__smt_env, ct.dc_phases[i].invariant)
+        return self.__fmgr.And(self.can_seep(p, i), inv)  # return And(can_seep(p, i), ct.dc_phases[i].invariant)
+
+    def keep(self, ct: Countertrace, p: PhaseSets, i: int, cp: str) -> FNode:
+        inv = substitute_free_variables(self.__smt_env, ct.dc_phases[i].invariant)
+        return self.__fmgr.And(
+            self.__fmgr.TRUE() if i in p.active else self.__fmgr.FALSE(),
+            inv,
+            (
+                self.__fmgr.LT(self.__fmgr.Symbol(cp + str(i), self.__tmgr.REAL()), ct.dc_phases[i].bound)
+                if ct.dc_phases[i].is_upper_bound() and self.can_seep(p, i) == self.__fmgr.FALSE()
+                else self.__fmgr.TRUE()
+            ),
+        )
+
+    def complete(self, ct: Countertrace, p: PhaseSets, i: int, cp: str) -> FNode:
+        result = self.__fmgr.TRUE() if i in p.active else self.__fmgr.FALSE()
+
         if i in p.wait:
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_gteq(i) if i in p.gteq else p_.add_wait(i),
-                    resets,
-                    And(guard, keep[i], LT(Symbol(cp + str(i), REAL), ct.dc_phases[i].bound)),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
-            )
-
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_active(i),
-                    resets,
-                    And(guard, keep[i], GE(Symbol(cp + str(i), REAL), ct.dc_phases[i].bound)),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
+            result = self.__fmgr.And(
+                result,
+                (
+                    self.__fmgr.GE(self.__fmgr.Symbol(cp + str(i), self.__tmgr.REAL()), ct.dc_phases[i].bound)
+                    if i in p.gteq
+                    else self.__fmgr.FALSE()
+                ),
             )
         else:
-            result.extend(
-                build_successors(i + 1, p, p_.add_active(i), resets, And(guard, keep[i]), ct, enter, keep, cp)
+            result = self.__fmgr.And(
+                result,
+                (
+                    self.__fmgr.LT(self.__fmgr.Symbol(cp + str(i), self.__tmgr.REAL()), ct.dc_phases[i].bound)
+                    if i in p.less
+                    else self.__fmgr.TRUE()
+                ),
             )
 
-    elif ct.dc_phases[i].is_upper_bound() and can_seep(p_, i) == FALSE():
-        # Case 2c: clock i in resets
-        if ct.dc_phases[i].bound_type == Countertrace.BoundTypes.LESS:
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_less(i),
-                    resets.union({cp + str(i)}),
-                    And(guard, enter[i] or can_seep(p, i)),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
-            )
-            """
-            result.extend(build_successors(i + 1, p, p_.add_less(i), resets.union({cp + str(i)}),
-                                           And(guard, enter[i]),
-                                           ct, enter, keep, cp))
+        if i > 0 and ct.dc_phases[i].allow_empty:
+            result = self.__fmgr.Or(result, self.complete(ct, p, i - 1, cp))
 
-            result.extend(build_successors(i + 1, p, p_.add_less(i), resets.union({cp + str(i)}),
-                                           And(guard, can_seep(p, i)),
-                                           ct, enter, keep, cp))
-            """
-        else:
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_less(i),
-                    resets.union({cp + str(i)}),
-                    And(guard, Not(enter[i]), can_seep(p, i)),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
-            )
+        return result
 
-            result.extend(
-                build_successors(
-                    i + 1, p, p_.add_active(i), resets.union({cp + str(i)}), And(guard, enter[i]), ct, enter, keep, cp
-                )
-            )
+    def can_seep(self, p: PhaseSets, i: int) -> FNode:
+        return self.__fmgr.TRUE() if i - 1 in p.active.difference(p.wait) else self.__fmgr.FALSE()
 
-            # result.extend(build_successors(i + 1, p, p_.add_less(i), resets.union({cp + str(i)}), # wrong
-            #                               And(guard, enter[i], can_seep(p, i)),
-            #                               ct, enter, keep, cp))
+    def simplify_with_z3(self, f: FNode) -> FNode:
+        tactic = Then(With(Tactic("simplify"), elim_and=True), Tactic("propagate-values"))
+        result = tactic(self.__solver.converter.convert(f)).as_expr()
+        result = self.__solver.converter.back(result)
 
-        # Case 2e: clock i not in resets
-        if i in p.less:
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_less(i),
-                    resets,
-                    And(guard, Not(enter[i]), Not(can_seep(p, i))),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
-            )
-        else:
-            result.extend(
-                build_successors(
-                    i + 1,
-                    p,
-                    p_.add_active(i),
-                    resets,
-                    And(guard, Not(enter[i]), Not(can_seep(p, i))),
-                    ct,
-                    enter,
-                    keep,
-                    cp,
-                )
-            )
+        # TODO: Implement this in a testcase.
+        # assert is_valid(Iff(f, result)), f"Failed to simplify: {f} is not equivalent to {result}"
 
-    else:
-        # i in p_.active
-        result.extend(build_successors(i + 1, p, p_.add_active(i), resets, guard, ct, enter, keep, cp))
-
-    return result
-
-
-def compute_enter_keep(
-        ct: Countertrace, p: PhaseSets, init: bool, cp: str
-) -> tuple[dict[int, FNode], dict[int, FNode]]:
-    enter_, keep_ = {}, {}
-
-    if init:
-        for i in range(-1, len(ct.dc_phases)):
-            inv = substitute_free_variables(ct.dc_phases[i].invariant)
-            enter_[i] = (
-                TRUE() if i < 0 else And(enter_[i - 1], TRUE() if ct.dc_phases[i - 1].allow_empty else FALSE(), inv)
-            )
-            # enter_[i] = TRUE() if i < 0 else And(
-            #   enter_[i - 1],
-            #   TRUE() if ct.dc_phases[i - 1].allow_empty else FALSE(),
-            #   ct.dc_phases[i].invariant)
-            keep_[i] = FALSE()
-    else:
-        for i in range(len(ct.dc_phases)):
-            enter_[i] = enter(ct, p, i, cp)
-            keep_[i] = keep(ct, p, i, cp)
-
-    return enter_, keep_
-
-
-def enter(ct: Countertrace, p: PhaseSets, i: int, cp: str) -> FNode:
-    inv = substitute_free_variables(ct.dc_phases[i].invariant)
-    return And(complete(ct, p, i - 1, cp), inv)  # return And(complete(ct, p, i - 1), ct.dc_phases[i].invariant)
-
-
-def seep(ct: Countertrace, p: PhaseSets, i: int) -> FNode:
-    inv = substitute_free_variables(ct.dc_phases[i].invariant)
-    return And(can_seep(p, i), inv)  # return And(can_seep(p, i), ct.dc_phases[i].invariant)
-
-
-def keep(ct: Countertrace, p: PhaseSets, i: int, cp: str) -> FNode:
-    inv = substitute_free_variables(ct.dc_phases[i].invariant)
-    return And(
-        TRUE() if i in p.active else FALSE(),
-        inv,
-        (
-            LT(Symbol(cp + str(i), REAL), ct.dc_phases[i].bound)
-            if ct.dc_phases[i].is_upper_bound() and can_seep(p, i) == FALSE()
-            else TRUE()
-        ),
-    )
-
-    # return And(TRUE() if i in p.active else FALSE(), ct.dc_phases[i].invariant,
-    #           LT(Symbol(cp + str(i), INT), ct.dc_phases[i].bound)
-    #           if ct.dc_phases[i].is_upper_bound() and can_seep(p, i) == FALSE() else TRUE())
-
-
-def complete(ct: Countertrace, p: PhaseSets, i: int, cp: str) -> FNode:
-    result = TRUE() if i in p.active else FALSE()
-
-    if i in p.wait:
-        result = And(result, GE(Symbol(cp + str(i), REAL), ct.dc_phases[i].bound) if i in p.gteq else FALSE())
-    else:
-        result = And(result, LT(Symbol(cp + str(i), REAL), ct.dc_phases[i].bound) if i in p.less else TRUE())
-
-    if i > 0 and ct.dc_phases[i].allow_empty:
-        result = Or(result, complete(ct, p, i - 1, cp))
-
-    return result
-
-
-def can_seep(p: PhaseSets, i: int) -> FNode:
-    return TRUE() if i - 1 in p.active.difference(p.wait) else FALSE()
-
-
-def simplify_with_z3(f: FNode) -> FNode:
-    tactic = Then(With(Tactic("simplify"), elim_and=True), Tactic("propagate-values"))
-    result = tactic(solver_z3.converter.convert(f)).as_expr()
-    result = solver_z3.converter.back(result)
-
-    # TODO: Implement this in a testcase.
-    #assert is_valid(Iff(f, result)), f"Failed to simplify: {f} is not equivalent to {result}"
-
-    return result
+        return result

--- a/hanfor/lib_pea/formal_utils.py
+++ b/hanfor/lib_pea/formal_utils.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
 
 from lib_core import boogie_parsing
@@ -10,26 +11,29 @@ if TYPE_CHECKING:
     from lib_core.data import Requirement, VariableCollection, Formalization
 
 
-def get_expression_mapping_smt(f: "Formalization", vc: "VariableCollection") -> dict[str, FNode]:
+def get_expression_mapping_smt(smt_env: Environment, f: "Formalization", vc: "VariableCollection") -> dict[str, FNode]:
     expressions = {}
 
     for k, v in f.expressions_mapping.items():
         # Todo: hack to detect empty expressions (why is this necessary now)?
         if not v.raw_expression:
             continue
-        expressions[k] = get_smt_expression(f, vc, k)
+        expressions[k] = get_smt_expression(smt_env, f, vc, k)
 
     return expressions
 
 
-def get_smt_expression(f: "Formalization", vc: "VariableCollection", letter: str) -> FNode:
+def get_smt_expression(smt_env: Environment, f: "Formalization", vc: "VariableCollection", letter: str) -> FNode:
     boogie_parser = boogie_parsing.get_parser_instance()
     tree = boogie_parser.parse(f.expressions_mapping[letter].raw_expression)
-    return BoogiePysmtTransformer(set(vc.collection.values())).transform(tree)
+    return BoogiePysmtTransformer(smt_env, set(vc.collection.values())).transform(tree)
 
 
 def get_semantics_from_requirement(
-    requirement: "Requirement", requirements: list["Requirement"], var_collection: "VariableCollection"
+    smt_env: Environment,
+    requirement: "Requirement",
+    requirements: list["Requirement"],
+    var_collection: "VariableCollection",
 ) -> dict[tuple["Formalization", int], Countertrace]:
     """Instanciate the semantics of a single requirement.
     All other requirements should be passed in to allow for complexer patterns to be generated"""
@@ -46,7 +50,7 @@ def get_semantics_from_requirement(
 
         other_formalisations = [f for r in requirements for f in r.formalizations.values() if f is not formalization]
         for i, ct in enumerate(
-            pattern.get_instanciated_countertraces(scope, formalization, other_formalisations, var_collection)
+            pattern.get_instanciated_countertraces(smt_env, scope, formalization, other_formalisations, var_collection)
         ):
             dc_formulas[(formalization, i)] = ct
 

--- a/hanfor/lib_pea/location.py
+++ b/hanfor/lib_pea/location.py
@@ -1,20 +1,25 @@
 from dataclasses import dataclass
 from fractions import Fraction
 
+import numexpr
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.formula import FormulaManager
-from pysmt.shortcuts import TRUE, is_valid, Iff
 
 from lib_pea.phase_sets import PhaseSets
-from lib_pea.config import SOLVER_NAME, LOGIC
-import numexpr
 
 
 @dataclass(unsafe_hash=True)
 class Location:
-    state_invariant: FNode = TRUE()
-    clock_invariant: FNode = TRUE()
+    smt_env: Environment
+    state_invariant: FNode = None
+    clock_invariant: FNode = None
     label: str = None
+
+    def __post_init__(self):
+        if self.state_invariant is None:
+            self.state_invariant = self.smt_env.formula_manager.TRUE()
+        if self.clock_invariant is None:
+            self.clock_invariant = self.smt_env.formula_manager.TRUE()
 
     def __str__(self):
         return f"{self.label:<10}: {str(self.state_invariant):<40}, {str(self.clock_invariant):<20}"
@@ -22,14 +27,19 @@ class Location:
 
 @dataclass
 class PhaseSetsLocation(Location):
+    smt_env: Environment
     label: PhaseSets = PhaseSets()
 
     def __eq__(self, o: "PhaseSetsLocation") -> bool:
         return (
             isinstance(o, PhaseSetsLocation)
             and o.label == self.label
-            and is_valid(Iff(o.state_invariant, self.state_invariant), solver_name=SOLVER_NAME, logic=LOGIC)
-            and is_valid(Iff(o.clock_invariant, self.clock_invariant), solver_name=SOLVER_NAME, logic=LOGIC)
+            and self.smt_env.factory.get_solver(name="z3").is_valid(
+                self.smt_env.formula_manager.Iff(o.state_invariant, self.state_invariant)
+            )
+            and self.smt_env.factory.get_solver(name="z3").is_valid(
+                self.smt_env.formula_manager.Iff(o.clock_invariant, self.clock_invariant)
+            )
         )
 
     def __hash__(self) -> int:
@@ -41,12 +51,13 @@ class PhaseSetsLocation(Location):
     def __repr__(self):
         return str(self.label)
 
-    def normalize(self, formula_manager: FormulaManager) -> None:
-        if self.state_invariant not in formula_manager:
-            self.state_invariant = formula_manager.normalize(self.state_invariant)
+    def normalize(self) -> None:
+        fmgr = self.smt_env.formula_manager
+        if self.state_invariant not in fmgr:
+            self.state_invariant = fmgr.normalize(self.state_invariant)
 
-        if self.clock_invariant not in formula_manager:
-            self.clock_invariant = formula_manager.normalize(self.clock_invariant)
+        if self.clock_invariant not in fmgr:
+            self.clock_invariant = fmgr.normalize(self.clock_invariant)
 
     def get_min_clock_bound(self) -> tuple[str, float, bool] | None:
         result = None

--- a/hanfor/lib_pea/location.py
+++ b/hanfor/lib_pea/location.py
@@ -31,16 +31,14 @@ class PhaseSetsLocation(Location):
     label: PhaseSets = PhaseSets()
 
     def __eq__(self, o: "PhaseSetsLocation") -> bool:
-        return (
-            isinstance(o, PhaseSetsLocation)
-            and o.label == self.label
-            and self.smt_env.factory.get_solver(name="z3").is_valid(
+        if not isinstance(o, PhaseSetsLocation):
+            return False
+        if not o.label == self.label:
+            return False
+        with self.smt_env.factory.get_solver(name="z3") as solver:
+            return solver.is_valid(
                 self.smt_env.formula_manager.Iff(o.state_invariant, self.state_invariant)
-            )
-            and self.smt_env.factory.get_solver(name="z3").is_valid(
-                self.smt_env.formula_manager.Iff(o.clock_invariant, self.clock_invariant)
-            )
-        )
+            ) and solver.is_valid(self.smt_env.formula_manager.Iff(o.clock_invariant, self.clock_invariant))
 
     def __hash__(self) -> int:
         return hash((self.label))

--- a/hanfor/lib_pea/pea.py
+++ b/hanfor/lib_pea/pea.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from pysmt.formula import FormulaManager
+from pysmt.environment import Environment
 
 from lib_pea.countertrace import Countertrace
 from lib_pea.location import PhaseSetsLocation, Location
@@ -9,9 +9,14 @@ from lib_pea.transition import PhaseSetsTransition, Transition
 
 
 class Pea(PeaOperationsMixin):
-    def __init__(self):
+    def __init__(
+        self,
+        smt_env: Environment,  # current  pySMT Environment (containing the right/current symbols and types)
+    ):
         self.transitions: defaultdict[Location, set[Transition]] = defaultdict(set)
         self.clocks: set[str] = set()
+        self._smt_env: Environment = smt_env
+        self._solver = self._smt_env.factory.get_solver(name="z3")
 
     def locations(self) -> set[Location]:
         return set(self.transitions.keys())
@@ -26,31 +31,23 @@ class Pea(PeaOperationsMixin):
 
 
 class PhaseSetsPea(Pea):
-    def __init__(self, countertrace: Countertrace = None):
-        super().__init__()
-
-        self.transitions: defaultdict[PhaseSetsLocation, set[PhaseSetsTransition]] = defaultdict(set)
+    def __init__(self, smt_env: Environment, countertrace: Countertrace):
+        super().__init__(smt_env)
+        self.transitions: defaultdict[PhaseSetsLocation | None, set[PhaseSetsTransition]] = defaultdict(set)
         self.countertrace: Countertrace = countertrace
         self.requirement = None
         self.formalization = None
-        self.countertrace_id: int = None
+        self.countertrace_id: int | None = None
 
     def __eq__(self, o: "PhaseSetsPea") -> bool:
         return isinstance(o, PhaseSetsPea) and o.transitions == self.transitions
 
-    @classmethod
-    def load(cls, path: str) -> "PhaseSetsPea":
-        # pea = super().load(path)
-        # pea.normalize(get_env().formula_manager)
-        # return pea
-        raise NotImplementedError
-
-    def normalize(self, formula_manager: FormulaManager) -> None:
-        self.countertrace.normalize(formula_manager)
+    def normalize(self) -> None:
+        self.countertrace.normalize()
 
         for transitions in self.transitions.values():
             for transition in transitions:
-                transition.normalize(formula_manager)
+                transition.normalize()
 
     def add_transition(self, transition: PhaseSetsTransition) -> None:
         if transition in self.transitions[transition.src]:

--- a/hanfor/lib_pea/pea_operations.py
+++ b/hanfor/lib_pea/pea_operations.py
@@ -1,8 +1,10 @@
 from collections import defaultdict
 from typing import Union, TYPE_CHECKING
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import FALSE, And, Symbol, Solver, simplify
+from pysmt.formula import FormulaManager
+from pysmt.solvers.z3 import Z3Solver
 from pysmt.walkers import IdentityDagWalker
 
 from lib_pea.location import Location
@@ -11,15 +13,12 @@ from lib_pea.transition import Transition
 if TYPE_CHECKING:
     from lib_pea.pea import Pea
 
-SOLVER_NAME = "z3"
-LOGIC = "UFLIRA"
-
 
 class PeaOperationsMixin:
 
     OP_TOKEN = 1
 
-    def intersect(self: Union["Pea", "PeaOperationsMixin"], other: "Pea") -> "Pea":
+    def intersect(self: Union["Pea", "PeaOperationsMixin"], other: "Pea", smt_env: Environment, solver) -> "Pea":
         """Naiive implementation of PEA intersection for building small examples"""
         from lib_pea.pea import Pea
 
@@ -27,10 +26,19 @@ class PeaOperationsMixin:
         # TODO Clock substitutions
         self_clocks = {c: f"{c}.{PeaOperationsMixin.OP_TOKEN-1}" for c in self.clocks}
         other_clocks = {c: f"{c}.{PeaOperationsMixin.OP_TOKEN}" for c in other.clocks}
-        result = Pea()
-        locations = PeaOperationsMixin.__union_locations(self.locations(), other.locations(), self_clocks, other_clocks)
+        result = Pea(smt_env)
+        locations = PeaOperationsMixin.__union_locations(
+            smt_env, self.locations(), other.locations(), self_clocks, other_clocks, smt_env.formula_manager, solver
+        )
         result.transitions = PeaOperationsMixin.__union_transitions(
-            self.transitions, other.transitions, locations, self_clocks, other_clocks
+            smt_env,
+            self.transitions,
+            other.transitions,
+            locations,
+            self_clocks,
+            other_clocks,
+            smt_env.formula_manager,
+            solver,
         )
         result.clocks = set(self_clocks.values()) | set(other_clocks.values())
         # TODO: Minimize away all false edges and locations
@@ -38,37 +46,43 @@ class PeaOperationsMixin:
 
     @staticmethod
     def __union_locations(
+        smt_env: Environment,
         self_locs: set[Location],
         other_locs: set[Location],
         self_clocks: dict[str, str],
         other_clocks: dict[str, str],
+        fm: FormulaManager,
+        solver: Z3Solver,
     ) -> dict[tuple[Location, Location], Location]:
         result = dict()
         for sl in self_locs:
             for ol in other_locs:
                 if not sl or not ol:
                     continue  # Cant combine an initial edge with a non-initnial edge
-                ul = Location(
+                ul = Location(smt_env,
                     state_invariant=PeaOperationsMixin.__conjunct_builder(
-                        sl.state_invariant, ol.state_invariant, self_clocks, other_clocks
+                        smt_env, sl.state_invariant, ol.state_invariant, self_clocks, other_clocks, fm, solver
                     ),
                     clock_invariant=PeaOperationsMixin.__conjunct_builder(
-                        sl.clock_invariant, ol.clock_invariant, self_clocks, other_clocks
+                        smt_env, sl.clock_invariant, ol.clock_invariant, self_clocks, other_clocks, fm, solver
                     ),
                     label=f"{sl.label}+{ol.label}",
                 )
-                if ul.state_invariant is FALSE() or ul.clock_invariant is FALSE():
+                if ul.state_invariant is fm.FALSE() or ul.clock_invariant is fm.FALSE():
                     continue
                 result[(sl, ol)] = ul
         return result
 
     @staticmethod
     def __union_transitions(
+        smt_env: Environment,
         self_transitions: defaultdict[Location, set[Transition]],
         other_transitions: defaultdict[Location, set[Transition]],
         locations: dict[tuple[Location, Location], Location],
         self_clocks: dict[str, str],
         other_clocks: dict[str, str],
+        fm: FormulaManager,
+        solver: Z3Solver,
     ) -> defaultdict[Location, set[Transition]]:
         result = defaultdict(set)
         for (self_loc, other_loc), union_loc in locations.items():
@@ -77,12 +91,15 @@ class PeaOperationsMixin:
                     if (st.dst, ot.dst) not in locations:
                         continue
                     ut = Transition(
+                        smt_env,
                         src=union_loc,
                         dst=locations[(st.dst, ot.dst)],
-                        guard=PeaOperationsMixin.__conjunct_builder(st.guard, ot.guard, self_clocks, other_clocks),
+                        guard=PeaOperationsMixin.__conjunct_builder(
+                            smt_env, st.guard, ot.guard, self_clocks, other_clocks, fm, solver
+                        ),
                         resets=frozenset({self_clocks[c] for c in st.resets} | {other_clocks[c] for c in ot.resets}),
                     )
-                    if ut.guard is FALSE():
+                    if ut.guard is fm.FALSE():
                         continue
                     result[union_loc].add(ut)
         # Build initial trainsitions
@@ -91,38 +108,51 @@ class PeaOperationsMixin:
                 if (si.dst, oi.dst) not in locations:
                     continue
                 ut = Transition(
+                    smt_env,
                     src=None,
                     dst=locations[(si.dst, oi.dst)],
-                    guard=PeaOperationsMixin.__conjunct_builder(si.guard, oi.guard, self_clocks, other_clocks),
+                    guard=PeaOperationsMixin.__conjunct_builder(
+                        smt_env, si.guard, oi.guard, self_clocks, other_clocks, fm, solver
+                    ),
                     resets=frozenset(),
                 )
-                if ut.guard is FALSE():
+                if ut.guard is fm.FALSE():
                     continue
                 result[None].add(ut)
         return result
 
     @staticmethod
     def __conjunct_builder(
-        self_junct: FNode, other_junct: FNode, self_clocks: dict[str, str], other_clocks: dict[str, str]
+        smt_env: Environment,
+        self_junct: FNode,
+        other_junct: FNode,
+        self_clocks: dict[str, str],
+        other_clocks: dict[str, str],
+        fm: FormulaManager,
+        solver: Z3Solver,
     ):
         """Just conjuct the two Fnodes, but make clocks unique before"""
-        self_junct = Renamer(self_clocks).walk(self_junct)
-        other_junct = Renamer(other_clocks).walk(other_junct)
-        g = And(self_junct, other_junct)
-        with Solver(name=SOLVER_NAME, logic=LOGIC) as solver:
-            if solver.is_unsat(g):
-                return FALSE()
-        g = simplify(g)
+        self_junct = Renamer(self_clocks, fm).walk(self_junct)
+        other_junct = Renamer(other_clocks, fm).walk(other_junct)
+        g = fm.And(self_junct, other_junct)
+        if solver.is_unsat(g):
+            return fm.FALSE()
+        g = smt_env.simplifier.simplify(g)
         return g
 
 
 class Renamer(IdentityDagWalker):
-    def __init__(self, renaming_dict: dict):
+    def __init__(
+        self,
+        renaming_dict: dict,
+        fm: FormulaManager,
+    ):
         IdentityDagWalker.__init__(self)
         self.renaming_dict = renaming_dict
+        self.fm = fm
 
     def walk_symbol(self, formula, args, **kwargs):
         # lambda s: Symbol("renamed_" + s.symbol_name(), s.symbol_type())
         if name := formula.symbol_name in self.renaming_dict:
-            return Symbol(self.renaming_dict[name], formula.symbol_type())
+            return self.fm.Symbol(self.renaming_dict[name], formula.symbol_type())
         return formula

--- a/hanfor/lib_pea/req_to_pea.py
+++ b/hanfor/lib_pea/req_to_pea.py
@@ -1,9 +1,12 @@
+from pysmt.environment import Environment
+
 from lib_core.data import Formalization, Requirement
 from lib_pea.countertrace import Countertrace
-from lib_pea.countertrace_to_pea import build_automaton
+from lib_pea.countertrace_to_pea import PeaBuilder
 from lib_pea.pea import PhaseSetsPea
 
 
 def get_pea_from_formalisation(req: Requirement, f: Formalization, i: int, ct: Countertrace) -> PhaseSetsPea:
     sfid = f"c_{req.rid}_{f.id}_{i}_"
-    return build_automaton(ct, sfid)
+    smt_env = Environment()
+    return PeaBuilder(smt_env).build_automaton(ct, sfid)

--- a/hanfor/lib_pea/transition.py
+++ b/hanfor/lib_pea/transition.py
@@ -29,15 +29,12 @@ class PhaseSetsTransition(Transition):
     dst: PhaseSetsLocation = None
 
     def __eq__(self, o: "PhaseSetsTransition") -> bool:
-        return (
-            isinstance(o, PhaseSetsTransition)
-            and o.src == self.src
-            and o.dst == self.dst
-            and o.resets == self.resets
-            and self.smt_env.factory.get_solver(name="z3").is_valid(
-                self.smt_env.formula_manager.Iff(o.guard, self.guard)
-            )
-        )
+        if not isinstance(o, PhaseSetsTransition):
+            return False
+        if not (o.src == self.src and o.dst == self.dst and o.resets == self.resets):
+            return False
+        with self.smt_env.factory.get_solver(name="z3") as solver:
+            return solver.is_valid(self.smt_env.formula_manager.Iff(o.guard, self.guard))
 
     def __hash__(self) -> int:
         return hash((self.src, self.dst, self.resets))

--- a/hanfor/lib_pea/transition.py
+++ b/hanfor/lib_pea/transition.py
@@ -1,20 +1,23 @@
 from dataclasses import dataclass
 from typing import Union
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.formula import FormulaManager
-from pysmt.shortcuts import TRUE, is_valid, Iff
 
 from lib_pea.location import PhaseSetsLocation, Location
-from lib_pea.config import SOLVER_NAME, LOGIC
 
 
 @dataclass(unsafe_hash=True)
 class Transition:
+    smt_env: Environment
     src: Union[None, Location] = None
     dst: Location = None
-    guard: FNode = TRUE()
+    guard: FNode = None
     resets: frozenset[str] = frozenset()
+
+    def __post_init__(self):
+        if not self.guard:
+            self.guard = self.smt_env.formula_manager.TRUE()
 
     def __str__(self):
         return f"{self.src.label if self.src else 'init':>15} --- {str(self.guard):<30} ({str(self.resets):>5}) ---> {self.dst.label:<15}"
@@ -22,7 +25,7 @@ class Transition:
 
 @dataclass
 class PhaseSetsTransition(Transition):
-    src: PhaseSetsLocation = None
+    src: PhaseSetsLocation | None = None
     dst: PhaseSetsLocation = None
 
     def __eq__(self, o: "PhaseSetsTransition") -> bool:
@@ -31,7 +34,9 @@ class PhaseSetsTransition(Transition):
             and o.src == self.src
             and o.dst == self.dst
             and o.resets == self.resets
-            and is_valid(Iff(o.guard, self.guard), solver_name=SOLVER_NAME, logic=LOGIC)
+            and self.smt_env.factory.get_solver(name="z3").is_valid(
+                self.smt_env.formula_manager.Iff(o.guard, self.guard)
+            )
         )
 
     def __hash__(self) -> int:
@@ -48,12 +53,13 @@ class PhaseSetsTransition(Transition):
     def __repr__(self):
         return str(self)
 
-    def normalize(self, formula_manager: FormulaManager) -> None:
+    def normalize(self) -> None:
+        fmgr = self.smt_env.formula_manager
         if self.src is not None:
-            self.src.normalize(formula_manager)
+            self.src.normalize()
 
         if self.dst is not None:
-            self.dst.normalize(formula_manager)
+            self.dst.normalize()
 
-        if self.guard not in formula_manager:
-            self.guard = formula_manager.normalize(self.guard)
+        if self.guard not in fmgr:
+            self.guard = fmgr.normalize(self.guard)

--- a/hanfor/lib_pea/utils.py
+++ b/hanfor/lib_pea/utils.py
@@ -1,7 +1,7 @@
 import graphviz
 from lark import Lark
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import Symbol, substitute
 
 from lib_pea.pea import PhaseSetsPea
 
@@ -22,13 +22,13 @@ def get_countertrace_parser() -> Lark:
     return CT_PARSER
 
 
-def substitute_free_variables(fnode: FNode, suffix: str = "_", do_nothing: bool = True) -> FNode:
+def substitute_free_variables(smt_env: Environment, fnode: FNode, suffix: str = "_", do_nothing: bool = True) -> FNode:
     if do_nothing:
         return fnode
 
     symbols = fnode.get_free_variables()
-    subs = {s: Symbol(s.symbol_name() + suffix, s.symbol_type()) for s in symbols}
-    result = substitute(fnode, subs)
+    subs = {s: smt_env.formula_manager.Symbol(s.symbol_name() + suffix, s.symbol_type()) for s in symbols}
+    result = smt_env.substituter.substitute(fnode, subs)
     return result
 
 

--- a/hanfor/quickchecks/check_poormanscomplete.py
+++ b/hanfor/quickchecks/check_poormanscomplete.py
@@ -2,8 +2,8 @@ import logging
 from dataclasses import dataclass
 from typing import List
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import FALSE, Or, Not, Solver, TRUE, get_free_variables, And, Bool, simplify
 from pysmt.walkers import IdentityDagWalker
 
 from json_db_connector.json_db import DatabaseField, DatabaseFieldType
@@ -52,10 +52,15 @@ class PoorMansComplete:
 
     CHECK_ID = "poormans_complete"
 
+    def __init__(self, smt_env: Environment):
+        self.__stm_env = smt_env
+        self.__fmgr = smt_env.formula_manager
+        self.__tmgr = smt_env.type_manager
+
     def run(self, reqs: list[Requirement], variables: set[Variable]) -> list[CompletenessCheckResult]:
         logging.info("Starting PoorMansComplete Analysis for requirements set...")
         results = []
-        smt_transformer = BoogiePysmtTransformer(variables)
+        smt_transformer = BoogiePysmtTransformer(self.__stm_env, variables)
         smt_to_vars = {
             smt_transformer.smt_vars[hanfor_var.name]: hanfor_var
             for hanfor_var in variables
@@ -63,28 +68,29 @@ class PoorMansComplete:
         }
         env_full = self.extract_environment_assumption(variables, smt_transformer)
         for target_var, hanfor_var in smt_to_vars.items():
-            env_assumptions = simplify(And([t for t in env_full if target_var in get_free_variables(t)]))
+            env_assumptions = self.__stm_env.simplifier.simplify(
+                self.__fmgr.And([t for t in env_full if target_var in self.__stm_env.fvo.get_free_variables(t)])
+            )
             # env_full  # ProjectionWalker(target_var).walk(env_full)
             terms = self.extract_reqs_term(smt_transformer, reqs, target_var)
             results.append(self.check_env_violated(terms, target_var, env_assumptions, hanfor_var))
-            results.append(self.check_complete_var(Or(terms), target_var, env_assumptions, hanfor_var))
+            results.append(self.check_complete_var(self.__fmgr.Or(terms), target_var, env_assumptions, hanfor_var))
         logging.info("... finished PoorMansComplete.")
         return results
 
-    @staticmethod
     def check_complete_var(
-        term: FNode, target_var: FNode, env_assumption: FNode, hanfor_var: Variable
+        self, term: FNode, target_var: FNode, env_assumption: FNode, hanfor_var: Variable
     ) -> CompletenessCheckResult:
         """Check if all values (under an environment) of a variable are possible in term"""
-        with Solver(name=SOLVER_NAME, logic=LOGIC) as solver:
-            q_form = And(Not(term), env_assumption)
+        with self.__stm_env.factory.get_solver(name="z3", logic=LOGIC) as solver:
+            q_form = self.__fmgr.And(self.__fmgr.Not(term), env_assumption)
             is_incomplete = solver.is_sat(q_form)
             if is_incomplete:
                 return CompletenessCheckResult(
                     hanfor_var.name,
                     (
                         CompletenessCheckOutcome.INCOMPLETE
-                        if target_var in get_free_variables(env_assumption)
+                        if target_var in self.__stm_env.fvo.get_free_variables(env_assumption)
                         else CompletenessCheckOutcome.INCOMPLETE_UNCONSTRAINT
                     ),
                     f"{target_var.symbol_name()}: value {solver.get_value(target_var)}  is uncovered.\n"
@@ -107,12 +113,13 @@ class PoorMansComplete:
         for req in reqs:
             terms.extend(self.extract_req_terms(smt_transformer, req, target_var))
         if use_projection:
-            terms = [ProjectionWalker(target_var).walk(term) for term in terms]
-        non_trivial_terms = [t for t in terms if t is not FALSE() and t is not TRUE()]
+            terms = [ProjectionWalker(self.__stm_env, target_var).walk(term) for term in terms]
+        non_trivial_terms = [t for t in terms if t is not self.__fmgr.FALSE() and t is not self.__fmgr.TRUE()]
         return non_trivial_terms
 
-    @staticmethod
-    def extract_req_terms(smt_transformer: BoogiePysmtTransformer, req: Requirement, target_var: FNode) -> List[FNode]:
+    def extract_req_terms(
+        self, smt_transformer: BoogiePysmtTransformer, req: Requirement, target_var: FNode
+    ) -> List[FNode]:
         parser = boogie_parsing.get_parser_instance()
         terms = []
         for _, formalisation in req.formalizations.items():
@@ -133,14 +140,13 @@ class PoorMansComplete:
                         f"Parsing error in requirement: {req.rid} expression `{expression.raw_expression}`.\n {e}"
                     )
                     continue
-                if target_var not in get_free_variables(smt_expr):
+                if target_var not in self.__stm_env.fvo.get_free_variables(smt_expr):
                     continue
                 terms.append(smt_expr)
         return terms
 
-    @staticmethod
     def extract_environment_assumption(
-        variables: set[Variable], smt_transformer: BoogiePysmtTransformer
+        self, variables: set[Variable], smt_transformer: BoogiePysmtTransformer
     ) -> List[FNode]:
         assumptions = []
         parser = boogie_parsing.get_parser_instance()
@@ -172,22 +178,21 @@ class PoorMansComplete:
                         case "Universality":
                             assumptions.append(smt_expr)
                         case "Absence":
-                            assumptions.append(Not(smt_expr))
+                            assumptions.append(self.__fmgr.Not(smt_expr))
         return assumptions
 
-    @staticmethod
     def check_env_violated(
-        terms: List[FNode], target_var: FNode, env_assumption: FNode, hanfor_var: Variable
+        self, terms: List[FNode], target_var: FNode, env_assumption: FNode, hanfor_var: Variable
     ) -> CompletenessCheckResult:
-        """Check if all values a variable can tanke are inside the environment (if applicable)"""
-        if target_var not in get_free_variables(env_assumption):
+        """Check if all values a variable can take are inside the environment (if applicable)"""
+        if target_var not in self.__stm_env.fvo.get_free_variables(env_assumption):
             return CompletenessCheckResult(
                 hanfor_var.name, CompletenessCheckOutcome.OK, f"'{target_var.symbol_name()}' has no env assumptions."
             )
-        with Solver(name=SOLVER_NAME, logic=LOGIC) as solver:
+        with self.__stm_env.factory.get_solver(name="z3", logic=LOGIC) as solver:
             for term in terms:
-                if target_var in get_free_variables(env_assumption):
-                    a_form = And(term, env_assumption)
+                if target_var in self.__stm_env.fvo.get_free_variables(env_assumption):
+                    a_form = self.__fmgr.And(term, env_assumption)
                     intersects_environment = solver.is_sat(a_form)
                     if not intersects_environment:
                         return CompletenessCheckResult(
@@ -202,10 +207,13 @@ class PoorMansComplete:
 
 
 class ProjectionWalker(IdentityDagWalker):
-    def __init__(self, variable):
+    def __init__(self, smt_env: Environment, variable):
         super().__init__()
         self.parents = {}
         self.variable = variable
+        self.__smt_env = smt_env
+        self.__fmgr = self.__smt_env.formula_manager
+        self.__tmgr = self.__smt_env.type_manager
 
     def walk(self, formula, **kwargs):
         for arg in formula.args():
@@ -214,37 +222,39 @@ class ProjectionWalker(IdentityDagWalker):
         return super().walk(formula, **kwargs)
 
     def walk_and(self, formula, args, **kwargs):
-        relevant_args = [f for f in args if self.variable in get_free_variables(f)]
+        relevant_args = [f for f in formula.args() if self.variable in self.__smt_env.fvo.get_free_variables(f)]
         if relevant_args:
-            return And(relevant_args)
+            return self.__fmgr.And(relevant_args)
         return self.__get_neutral_parent(formula)
 
     def walk_or(self, formula, args, **kwargs):
-        relevant_args = [f for f in args if self.variable in get_free_variables(f)]
+        relevant_args = [f for f in formula.args() if self.variable in self.__smt_env.fvo.get_free_variables(f)]
         if relevant_args:
-            return Or(relevant_args)
+            return self.__fmgr.Or(relevant_args)
         return self.__get_neutral_parent(formula)
 
     def __get_neutral_parent(self, formula):
         # if this leaf is empty, return the neutral element of the parent operator
-        if formula not in self.parents:
-            return Bool(True)
+        if formula not in self.parents:  # complicated way of checking that formula is the root
+            return self.__fmgr.Bool(True)
         par = self.parents[formula]
         if par.is_and():
-            return Bool(True)
+            return self.__fmgr.Bool(True)
+        elif par.is_or():
+            return self.__fmgr.Bool(False)
         elif par.is_not():
-            return self.__get_neutral_parent(par)
+            return self.__fmgr.Not(self.__get_neutral_parent(par))
         else:
             # TODO: figure out which nodes are there additionally (e.g. implication, just braces)
-            return Bool(True)
+            return self.__fmgr.Bool(True)
 
     def walk_not(self, formula, args, **kwargs):
         arg = args[0]
-        if self.variable in get_free_variables(arg):
-            return Not(arg)
+        if self.variable in self.__smt_env.fvo.get_free_variables(arg):
+            return self.__fmgr.Not(arg)
         return self.__get_neutral_parent(formula)
 
     def walk_atom(self, formula, **kwargs):
-        if self.variable in get_free_variables(formula):
+        if self.variable in self.__smt_env.fvo.get_free_variables(formula):
             return formula
         return self.__get_neutral_parent(formula)

--- a/hanfor/quickchecks/quickchecks.py
+++ b/hanfor/quickchecks/quickchecks.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Type
+
 from flask import Blueprint, render_template, Response
 from flask.views import MethodView
+from pysmt.environment import Environment
+
 from hanfor_flask import current_app
 from json_db_connector.json_db import DatabaseTable, TableType, DatabaseID, DatabaseField
-from quickchecks.check_poormanscomplete import PoorMansComplete, CompletenessCheckResult, CompletenessCheckOutcome
 from lib_core.data import Variable, Requirement
-
+from quickchecks.check_poormanscomplete import PoorMansComplete, CompletenessCheckResult, CompletenessCheckOutcome
 
 BUNDLE_JS = "dist/quickchecks-bundle.js"
 blueprint = Blueprint("quickchecks", __name__, template_folder="templates", url_prefix="/quickchecks")
@@ -61,7 +63,7 @@ class QuickcheckApi(MethodView):
     def run_checks() -> list[CompletenessCheckResult]:
         reqs = list(current_app.db.get_objects(Requirement).values())
         variables = set(current_app.db.get_objects(Variable).values())
-        results = PoorMansComplete().run(reqs, variables)
+        results = PoorMansComplete(Environment()).run(reqs, variables)
         for result in results:
             if result.outcome == CompletenessCheckOutcome.OK:
                 continue

--- a/hanfor/req_simulator/scenario.py
+++ b/hanfor/req_simulator/scenario.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass, field
 from fractions import Fraction
 from typing import Any
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import Symbol, Real, Bool, Int, TRUE
-from pysmt.typing import BOOL, INT, REAL
 
 from req_simulator.utils import load_json_or_yaml_file, parse_json_or_yaml_string, save_json_file, dump_json_string
 
@@ -15,16 +14,17 @@ from req_simulator.utils import load_json_or_yaml_file, parse_json_or_yaml_strin
 @dataclass
 class Configuration:
     time: float
-    variables: dict[FNode, FNode]
+    variables: dict[FNode, FNode | None]
 
 
-@dataclass
 class Scenario:
-    times: list[float]
-    variables: dict[FNode, list[FNode]]
-    types: dict[FNode, BOOL | INT | REAL] = field(init=False)
 
-    def __post_init__(self):
+    def __init__(self, smt_env: Environment, times=None, variables=None):
+        self.__smt_env = smt_env
+        self.__tmgr = self.__smt_env.type_manager
+        self.__fmgr = self.__smt_env.formula_manager
+        self.times: list[float] = times if times else []
+        self.variables: dict[FNode, list[FNode | None]] = variables if variables else {}
         self.types = {k: k.symbol_type() for k in self.variables}
 
     def remove_variable(self, variable: FNode) -> None:
@@ -41,7 +41,7 @@ class Scenario:
     def difference(self, variables: list[FNode]) -> list[FNode]:
         return [k for k in self.variables if k not in variables]
 
-    def get_configuration(self, time: float) -> Configuration:
+    def get_configuration(self, time: float) -> Configuration | None:
         result = None
 
         for i in range(len(self.times) - 1):
@@ -52,81 +52,58 @@ class Scenario:
 
         return result
 
-    @staticmethod
-    def from_object(object: Any) -> Scenario | None:
+    def from_object(self, object: Any) -> Scenario | None:
         if object is None:
             return None
 
         var_map = {
-            "Bool": lambda v: Symbol(v, BOOL),
-            "Int": lambda v: Symbol(v, INT),
-            "Real": lambda v: Symbol(v, REAL),
+            "Bool": lambda v: self.__fmgr.Symbol(v, self.__tmgr.BOOL()),
+            "Int": lambda v: self.__fmgr.Symbol(v, self.__tmgr.INT()),
+            "Real": lambda v: self.__fmgr.Symbol(v, self.__tmgr.REAL()),
         }
-
-        const_map = {"Bool": lambda v: Bool(v == 1), "Int": lambda v: Int(v), "Real": lambda v: Real(v)}
-
-        scenario = Scenario(
-            object["head"]["times"] + [object["head"]["duration"]],
-            {
-                var_map[v["type"]](k): [None] + [const_map[v["type"]](vv) for vv in v["values"]]
-                for k, v in object["data"].items()
-            },
-        )
-
-        return scenario
-
-    @staticmethod
-    def to_object(scenario: Scenario) -> Any:
-        if scenario is None:
-            return None
 
         const_map = {
-            BOOL: lambda v: v == TRUE(),
-            INT: lambda v: int(str(v)),
-            REAL: lambda v: float(Fraction(str(v))),
+            "Bool": lambda v: self.__fmgr.Bool(v == 1),
+            "Int": lambda v: self.__fmgr.Int(v),
+            "Real": lambda v: self.__fmgr.Real(v),
         }
 
-        head = {}
-        head["duration"] = scenario.times[-1]
-        head["times"] = [v for v in scenario.times[:-1]]
+        self.times = object["head"]["times"] + [object["head"]["duration"]]
+        self.variables = {
+            var_map[v["type"]](k): [None] + [const_map[v["type"]](vv) for vv in v["values"]]
+            for k, v in object["data"].items()
+        }
+        self.types = {k: k.symbol_type() for k in self.variables}
+        return self
 
-        data = defaultdict(dict)
-        for k, v in scenario.variables.items():
+    def to_object(self) -> Any:
+        const_map = {
+            self.__tmgr.BOOL(): lambda v: v == self.__fmgr.TRUE(),
+            self.__tmgr.INT(): lambda v: int(str(v)),
+            self.__tmgr.REAL(): lambda v: float(Fraction(str(v))),
+        }
+
+        head = dict()
+        head["duration"] = self.times[-1]
+        head["times"] = [v for v in self.times[:-1]]
+
+        data = defaultdict(dict[str, Any])
+        for k, v in self.variables.items():
             data[str(k)]["type"] = str(k.get_type())
-            data[str(k)]["values"] = [const_map[scenario.types[k]](v_) for v_ in v[1:]]
+            data[str(k)]["values"] = [const_map[self.types[k]](v_) for v_ in v[1:]]
 
         return {"head": head, "data": data}
 
-    @staticmethod
-    def from_json_string(str: str) -> Scenario:
-        return Scenario.from_object(parse_json_or_yaml_string(str))
+    def from_json_string(self, str: str) -> Scenario:
+        self.from_object(parse_json_or_yaml_string(str))
+        return self
 
-    @staticmethod
-    def to_json_string(scenario: Scenario) -> str:
-        return dump_json_string(Scenario.to_object(scenario))
+    def to_json_string(self) -> str:
+        return dump_json_string(self.to_object())
 
-    @staticmethod
-    def load_from_file(path: str) -> Scenario:
-        return Scenario.from_object(load_json_or_yaml_file(path))
+    def load_from_file(self, path: str) -> Scenario:
+        self.from_object(load_json_or_yaml_file(path))
+        return self
 
-    @staticmethod
-    def save_to_file(scenario: Scenario, path: str, sort_keys: bool = False) -> None:
-        save_json_file(Scenario.to_object(scenario), path)
-
-
-def main():
-    scenario = Scenario(
-        [0.0, 1.0, 2.0, 3.0],
-        {
-            Symbol("A"): [None, TRUE(), TRUE(), TRUE()],
-            Symbol("B", INT): [None, Int(5), Int(10), Int(0)],
-            Symbol("C", REAL): [None, Real(5.0), Real(10.0), Real(0.0)],
-        },
-    )
-
-    Scenario.save_to_file(scenario, "/home/ubuntu/Desktop/test_scenario.json")
-    scenario = Scenario.load_from_file("/home/ubuntu/Desktop/test_scenario.json")
-
-
-if __name__ == "__main__":
-    main()
+    def save_to_file(self, path: str, sort_keys: bool = False) -> None:
+        save_json_file(self.to_object(), path, sort_keys=sort_keys)

--- a/hanfor/req_simulator/simulator.py
+++ b/hanfor/req_simulator/simulator.py
@@ -5,19 +5,18 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Tuple, Any, Union
 
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
 from pysmt.rewritings import conjunctive_partition
-from pysmt.shortcuts import And, Equals, Symbol, Real, EqualsOrIff, get_model, is_sat, FALSE, get_unsat_core
-from pysmt.typing import REAL
 
-from lib_pea.config import SOLVER_NAME, LOGIC
-from lib_pea.countertrace_to_pea import complete
+from lib_core.data import Requirement, Formalization
+from lib_pea.config import SOLVER_NAME
+from lib_pea.countertrace_to_pea import PeaBuilder
 from lib_pea.location import PhaseSetsLocation
 from lib_pea.pea import PhaseSetsPea
 from lib_pea.transition import PhaseSetsTransition
 from req_simulator.scenario import Scenario
 from req_simulator.utils import num_zeros
-from lib_core.data import Requirement, Formalization
 
 
 class Simulator:
@@ -28,10 +27,20 @@ class Simulator:
         guard: FNode
 
     def __init__(
-        self, peas: list[PhaseSetsPea], scenario: Scenario = None, name: str = "unnamed", test: bool = False
+        self,
+        smt_env: Environment,
+        peas: list[PhaseSetsPea],
+        scenario: Scenario | None = None,
+        name: str = "unnamed",
+        test: bool = False,
     ) -> None:
         self.name: str = name
         self.scenario: Union[Scenario | None] = scenario
+
+        self.__smt_env: Environment = smt_env
+        self.__fmgr = self.__smt_env.formula_manager
+        self.__tmgr = self.__smt_env.type_manager
+        self.__solver = self.__smt_env.factory.get_solver(name=SOLVER_NAME)
 
         self.times: list[float] = [0.0]  # history
         self.time_steps: list[float] = [1.0]  # history
@@ -99,10 +108,13 @@ class Simulator:
             prefix = f"{self.peas[i].requirement.rid}_{self.peas[i].formalization.id}_{self.peas[i].countertrace_id}_"
 
             for v in current_phase.label.active:
-                is_complete = is_sat(
-                    And(complete(self.peas[i].countertrace, current_phase.label, v, "c_" + prefix), clock_assertions),
-                    solver_name=SOLVER_NAME,
-                    logic=LOGIC,
+                is_complete = self.__solver.is_sat(
+                    self.__fmgr.And(
+                        PeaBuilder(self.__smt_env).complete(
+                            self.peas[i].countertrace, current_phase.label, v, "c_" + prefix
+                        ),
+                        clock_assertions,
+                    )
                 )
 
                 if is_complete:
@@ -141,7 +153,7 @@ class Simulator:
     def save_scenario_to_file(self, path: str) -> None:
         Scenario.save_to_file(self.scenario, path)
 
-    def update_variables(self, variables: dict[FNode, FNode] = None) -> None:
+    def update_variables(self, variables: dict[FNode, FNode | None] = None) -> None:
         # TODO: fix scenario
         if variables is None and self.scenario is not None:
             variables = self.scenario.valuations.get(self.times[-1]).values
@@ -159,13 +171,14 @@ class Simulator:
 
         return result
 
-    @staticmethod
-    def build_variables_assertion(variables: dict[FNode, FNode]) -> FNode:
-        return And(EqualsOrIff(k, v) for k, v in variables.items() if v is not None)
+    def build_variables_assertion(self, variables: dict[FNode, FNode]) -> FNode:
+        return self.__fmgr.And(self.__fmgr.EqualsOrIff(k, v) for k, v in variables.items() if v is not None)
 
-    @staticmethod
-    def build_clocks_assertion(clocks: dict[str, float]) -> FNode:
-        return And(Equals(Symbol(k, REAL), Real(v)) for k, v in clocks.items())
+    def build_clocks_assertion(self, clocks: dict[str, float]) -> FNode:
+        return self.__fmgr.And(
+            self.__fmgr.Equals(self.__fmgr.Symbol(k, self.__tmgr.REAL()), self.__fmgr.Real(v))
+            for k, v in clocks.items()
+        )
 
     def calculate_max_time_step(self, transition: PhaseSetsTransition, clocks: dict[str, float], time_step: float):
         k, v = transition.dst.get_min_clock_bound()
@@ -212,8 +225,8 @@ class Simulator:
 
             for e in transitions:
                 # Check the guard with var and clock asserts.
-                if not is_sat(And(e.guard, var_asserts, clock_asserts), solver_name=SOLVER_NAME, logic=LOGIC):
-                    last_fail = And(e.guard, var_asserts, clock_asserts)
+                if not self.__solver.is_sat(self.__fmgr.And(e.guard, var_asserts, clock_asserts)):
+                    last_fail = self.__fmgr.And(e.guard, var_asserts, clock_asserts)
                     continue
 
                 # Compute duration to the closest bound, update clocks and build clock asserts.
@@ -222,7 +235,7 @@ class Simulator:
                 updated_clocks_assert = self.build_clocks_assertion(updated_clocks)
 
                 # Check the clock invariant of p'. (special case: last non-true phase has bound type '<=')
-                if not is_sat(And(e.dst.clock_invariant, updated_clocks_assert), solver_name=SOLVER_NAME, logic=LOGIC):
+                if not self.__solver.is_sat(self.__fmgr.And(e.dst.clock_invariant, updated_clocks_assert)):
                     continue
 
                 result_.append(e)
@@ -234,12 +247,9 @@ class Simulator:
                 if len(transitions) <= 0:
                     reason += "inconsistency"
                 else:
-                    unsat_core = get_unsat_core(conjunctive_partition(last_fail))
+                    unsat_core = self.__solver.get_unsat_core(conjunctive_partition(last_fail))
                     unsat_core = "Unknown" if not unsat_core else "\n" + ", ".join([f.serialize() for f in unsat_core])
                     reason += "unrealizable input, " + unsat_core
-
-                # reason = 'inconsistency' if len(transitions) <= 0 else \
-                #    'unrealizable input, ' + get_unsat_core(conjunctive_partition(last_fail))
 
                 self.sat_error = "Requirement violation: %s, Formalization: %s, Countertrace: %s\nReason: %s" % (
                     self.peas[i].requirement.rid,
@@ -290,8 +300,8 @@ class Simulator:
 
         # Terminate if tuple of transitions is complete.
         if i >= len(phases):
-            # model = get_model(guard, solver_name=SOLVER_NAME, logic=LOGIC)
-            model = get_model(And(guard, var_asserts, clock_asserts), solver_name=SOLVER_NAME, logic=LOGIC)
+            self.__solver.is_sat(self.__fmgr.And(guard, var_asserts, clock_asserts))
+            model = self.__solver.get_model()
             values = model.get_values(self.variables.keys())
             values.update({k: v[-1] for k, v in self.variables.items() if v[-1] is not None})
 
@@ -302,9 +312,11 @@ class Simulator:
 
         for transition in phases[i]:
             # Check conjunction of guards including the one of this transition with var and clock asserts.
-            guard_ = And(guard, transition.guard) if guard is not None else And(transition.guard)
+            guard_ = (
+                self.__fmgr.And(guard, transition.guard) if guard is not None else self.__fmgr.And(transition.guard)
+            )
 
-            if not is_sat(And(guard_, var_asserts, clock_asserts), solver_name=SOLVER_NAME, logic=LOGIC):
+            if not self.__solver.is_sat(self.__fmgr.And(guard_, var_asserts, clock_asserts)):
                 self.last_fail = guard_
                 continue
 
@@ -323,12 +335,12 @@ class Simulator:
         if i == 0 and len(result) == 0:
             reason = ""
 
-            if is_sat(And(self.last_fail, clock_asserts)):
+            if self.__solver.is_sat(self.__fmgr.And(self.last_fail, clock_asserts)):
                 reason += "unrealizable input"
             else:
                 reason += "inconsistency" if self.current_phases[-1][0] == None else "rt-inconsistency"
 
-            unsat_core = get_unsat_core(conjunctive_partition(self.last_fail))
+            unsat_core = self.__solver.get_unsat_core(conjunctive_partition(self.last_fail))
             unsat_core = "Unknown" if not unsat_core else "\n" + ", ".join([f.serialize() for f in unsat_core])
 
             self.sat_error = "Requirement violation: %s, Formalization: %s, Countertrace: %s\nReason: %s, %s" % (
@@ -413,3 +425,7 @@ class Simulator:
     def inconsistency_pre_check(self):
         # TODO: Do not modify existing member variables ;-)
         print("Called function inconsistency pre check ...")
+
+    @property
+    def smt_env(self):
+        return self.__smt_env

--- a/hanfor/requirements/requirements.py
+++ b/hanfor/requirements/requirements.py
@@ -41,7 +41,7 @@ def index():
         query=request.args,
         additional_cols=additional_cols,
         default_cols=default_cols,
-        patterns=APattern().to_frontent_dict(),
+        patterns=APattern.to_frontent_dict(),
     )
 
 

--- a/hanfor/ressources/simulator_ressource.py
+++ b/hanfor/ressources/simulator_ressource.py
@@ -1,13 +1,10 @@
-from __future__ import annotations
-
 import json
 import logging
 import time
 import uuid
 
 from flask import render_template
-from pysmt.shortcuts import Bool, Int, Real
-from pysmt.typing import BOOL, INT, REAL
+from pysmt.environment import Environment
 
 from lib_core.data import Requirement, VariableCollection, Variable
 from lib_core.pattern.patterns_basic import APattern
@@ -20,8 +17,6 @@ from lib_pea.utils import strtobool
 from req_simulator.scenario import Scenario
 from req_simulator.simulator import Simulator
 from ressources import Ressource
-
-validation_patterns = {BOOL: r"^0|false|False|1|true|True$", INT: r"^[+-]?\d+$", REAL: r"^[+-]?\d*[.]?\d+$"}
 
 
 class SimulatorRessource(Ressource):
@@ -117,6 +112,12 @@ class SimulatorRessource(Ressource):
             return
 
         simulator = self.simulator_cache[self.response.data["simulator_id"]]
+        tmgr = simulator.smt_env.type_manager
+        validation_patterns = {
+            tmgr.BOOL(): r"^0|false|False|1|true|True$",
+            tmgr.INT(): r"^[+-]?\d+$",
+            tmgr.REAL(): r"^[+-]?\d*[.]?\d+$",
+        }
         self.response.data["html"] = render_template(
             "simulator-modal/modal.html",
             simulator=simulator,
@@ -128,12 +129,13 @@ class SimulatorRessource(Ressource):
             return
 
         simulator = self.simulator_cache[self.response.data["simulator_id"]]
-        scenario = Scenario(simulator.times, {k: v for k, v in simulator.models.items()})
-        self.response.data["scenario_str"] = Scenario.to_json_string(scenario)
+        scenario = Scenario(simulator.smt_env, simulator.times, {k: v for k, v in simulator.models.items()})
+        self.response.data["scenario_str"] = scenario.to_json_string()
 
     def create_simulator(self) -> None:
         requirement_ids = json.loads(self.request.form.get("requirement_ids"))
         simulator_name = self.request.form.get("simulator_name")
+        smt_env = Environment()
 
         if len(requirement_ids) <= 0:
             self.response.success = False
@@ -150,7 +152,7 @@ class SimulatorRessource(Ressource):
             # filter for selected requirements
             if requirement.rid not in requirement_ids:
                 continue
-            cts = get_semantics_from_requirement(requirement, requirements, var_collection)
+            cts = get_semantics_from_requirement(smt_env, requirement, requirements, var_collection)
             for (f, i), ct in cts.items():
                 pea = get_pea_from_formalisation(requirement, f, i, ct)
                 pea.requirement = requirement
@@ -159,7 +161,7 @@ class SimulatorRessource(Ressource):
                 peas.append(pea)
 
         simulator_id = uuid.uuid4().hex
-        self.simulator_cache[simulator_id] = Simulator(peas, name=simulator_name)
+        self.simulator_cache[simulator_id] = Simulator(smt_env, peas, name=simulator_name)
 
         self.response.data = {"simulator_id": simulator_id, "simulator_name": simulator_name}
 
@@ -187,14 +189,14 @@ class SimulatorRessource(Ressource):
             for formalization in requirement.formalizations.values():
                 counter_traces = []
                 if not formalization.scoped_pattern.is_instantiatable():
-                    return None
+                    return
                 if has_variable_with_unknown_type(formalization, variables) or formalization.type_inference_errors:
-                    return None
+                    return
 
                 scope = formalization.scoped_pattern.scope.name
                 pattern = formalization.scoped_pattern.pattern.name
 
-                if APattern().get_pattern(pattern).has_countertraces(scope):
+                if APattern.get_pattern(pattern).has_countertraces(scope):
                     raise ValueError(f"No countertrace given: {scope}, {pattern}")
 
                 expressions = {}
@@ -230,9 +232,9 @@ class SimulatorRessource(Ressource):
             self.response.errormsg = "No scenario given."
             return
 
-        scenario = Scenario.from_json_string(scenario_str)
         simulator = self.simulator_cache[simulator_id]
-        self.simulator_cache[simulator_id] = Simulator(simulator.peas, scenario, simulator.name)
+        scenario = Scenario(simulator.smt_env).from_json_string(scenario_str)
+        self.simulator_cache[simulator_id] = Simulator(simulator.smt_env, simulator.peas, scenario, simulator.name)
 
         self.get_simulator()
 
@@ -254,10 +256,12 @@ class SimulatorRessource(Ressource):
         simulator.max_results = int(max_results)
 
         var_str_mapping = {str(k): k for k in simulator.variables}
+        tmgr = simulator.smt_env.type_manager
+        fmgr = simulator.smt_env.formula_manager
         const_mapping = {
-            BOOL: lambda v: Bool(bool(strtobool(v))),
-            INT: lambda v: Int(int(v)),
-            REAL: lambda v: Real(float(v)),
+            tmgr.BOOL(): lambda v: fmgr.Bool(bool(strtobool(v))),
+            tmgr.INT(): lambda v: fmgr.Int(int(v)),
+            tmgr.REAL(): lambda v: fmgr.Real(float(v)),
         }
 
         variables = {

--- a/hanfor/tags/tags.py
+++ b/hanfor/tags/tags.py
@@ -1,11 +1,12 @@
-from hanfor_flask import current_app
-from flask import Blueprint, render_template, request
-from flask_restx import Resource, Namespace
 from dataclasses import asdict
 
-from lib_core.data import Tag, Requirement
-from lib_core.api_models import TagModel, TagListModel, TagRequestModel, ErrorMessageModel
+from flask import Blueprint, render_template, request
+from flask_restx import Resource, Namespace
+
 from configuration.tags import STANDARD_TAGS
+from hanfor_flask import current_app
+from lib_core.api_models import TagModel, TagListModel, TagRequestModel, ErrorMessageModel
+from lib_core.data import Tag, Requirement
 
 BUNDLE_JS = "dist/tags-bundle.js"
 blueprint = Blueprint("tags", __name__, template_folder="templates", url_prefix="/tags")
@@ -77,7 +78,7 @@ class ApiTag(Resource):
         internal = bool(data["internal"])
         description = data["description"].strip()
 
-        if name in [t.name for t in current_app.db.get_objects(Tag).values() if t.uuid != tag.uuid]:  # type: Tag
+        if name in [t.name for t in current_app.db.get_objects(Tag).values() if t.uuid != tag.uuid]:
             return {"error": "Bad Request", "message": "Name exist already"}, 400
         tag.name = name
         tag.color = color

--- a/hanfor/tests/test_autreq_to_dc_complex.py
+++ b/hanfor/tests/test_autreq_to_dc_complex.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
 from unittest import TestCase
 
+from pysmt.environment import Environment
+
 from lib_core.data import *
 from lib_core.pattern.patterns_automata import AAutomatonPattern
-from lib_pea.countertrace import Countertrace
+from lib_pea.countertrace import BoundTypes
 
 
 class TestComplexAutomaton(TestCase):
@@ -167,13 +169,16 @@ class TestComplexAutomaton(TestCase):
         return variable_collection, r, f1, f2, f3, f5a, f5b, f6a, f6b, f7, f8
 
     def test_assembly(self):
+        smt_env = Environment()
         variable_collection, r, f1, f2, f3, f5a, f5b, f6a, f6b, f7, f8 = self.__get_complex_automaton()
         # First automaton
-        req_belonging_to_r = AAutomatonPattern.get_hull(f1, [f for f in r.formalizations.values()], variable_collection)
+        req_belonging_to_r = AAutomatonPattern.get_hull(
+            smt_env, f1, [f for f in r.formalizations.values()], variable_collection
+        )
         self.assertSetEqual({f1, f2, f3, f6a, f6b}, set(req_belonging_to_r))
         # Second Automaton
         req_belonging_to_r = AAutomatonPattern.get_hull(
-            f5a, [f for f in r.formalizations.values()], variable_collection
+            smt_env, f5a, [f for f in r.formalizations.values()], variable_collection
         )
         self.assertSetEqual({f5a, f5b, f7, f8}, set(req_belonging_to_r))
 
@@ -183,32 +188,32 @@ class TestComplexAutomaton(TestCase):
         aut = {f1, f2, f3, f6a, f6b}
 
         formal_f6a = f6a.scoped_pattern.get_patternish().get_instanciated_countertraces(
-            f6a.scoped_pattern.scope, f6a, aut, variable_collection
+            Environment(), f6a.scoped_pattern.scope, f6a, aut, variable_collection
         )
         # basic transition formula
         self.assertIsNotNone(formal_f6a)
-        self.assertIn(r"(= states 3)", formal_f6a[0].dc_phases[1].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(= states 1)", formal_f6a[0].dc_phases[2].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(< 22.0 aGuardingVar)", formal_f6a[0].dc_phases[2].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(= states 3)", formal_f6a[0].dc_phases[2].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(< aGuardingVar 5.0)", formal_f6a[0].dc_phases[2].invariant.to_smtlib(daggify=False))
+        self.assertIn(r"(states = 3)", formal_f6a[0].dc_phases[1].invariant.serialize())
+        self.assertIn(r"(states = 1)", formal_f6a[0].dc_phases[2].invariant.serialize())
+        self.assertIn(r"(22.0 < aGuardingVar)", formal_f6a[0].dc_phases[2].invariant.serialize())
+        self.assertIn(r"(states = 3)", formal_f6a[0].dc_phases[2].invariant.serialize())
+        self.assertIn(r"(aGuardingVar < 5.0)", formal_f6a[0].dc_phases[2].invariant.serialize())
         # formula for minimum duration in C
-        self.assertIn(r"(= states 3)", formal_f6a[1].dc_phases[1].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"55.0", formal_f6a[1].dc_phases[1].bound.to_smtlib(daggify=False))
-        self.assertEqual(Countertrace.BoundTypes.LESS, formal_f6a[1].dc_phases[1].bound_type)
-        self.assertIn(r"(= states 1)", formal_f6a[1].dc_phases[2].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(= states 2)", formal_f6a[1].dc_phases[2].invariant.to_smtlib(daggify=False))
+        self.assertIn(r"(states = 3)", formal_f6a[1].dc_phases[1].invariant.serialize())
+        self.assertIn(r"55.0", formal_f6a[1].dc_phases[1].bound.serialize())
+        self.assertEqual(BoundTypes.LESS, formal_f6a[1].dc_phases[1].bound_type)
+        self.assertIn(r"(states = 1)", formal_f6a[1].dc_phases[2].invariant.serialize())
+        self.assertIn(r"(states = 2)", formal_f6a[1].dc_phases[2].invariant.serialize())
 
     def test_edge_GE(self):
         variable_collection, r, f1, f2, f3, f5a, f5b, f6a, f6b, f7, f8 = self.__get_complex_automaton()
         # test general automaton layout
         aut = {f1, f2, f3, f6a, f6b}
-
+        env = Environment()
         formal_f2 = f2.scoped_pattern.get_patternish().get_instanciated_countertraces(
-            f2.scoped_pattern.scope, f2, aut, variable_collection
+            env, f2.scoped_pattern.scope, f2, aut, variable_collection
         )
-        self.assertIn(r"anOtherEventVar", formal_f2[0].dc_phases[1].invariant.to_smtlib(daggify=False))
-        self.assertNotIn(r"anOtherEventVar", formal_f2[0].dc_phases[2].invariant.to_smtlib(daggify=False))
+        self.assertIn(r"anOtherEventVar", formal_f2[0].dc_phases[1].invariant.serialize())
+        self.assertNotIn(r"anOtherEventVar", formal_f2[0].dc_phases[2].invariant.serialize())
 
     def test_edge_GEL(self):
         pass  # TODO

--- a/hanfor/tests/test_autreq_to_dc_simple.py
+++ b/hanfor/tests/test_autreq_to_dc_simple.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from unittest import TestCase
 
+from pysmt.environment import Environment
+
 from lib_core.data import *
 from lib_core.pattern.patterns_automata import AAutomatonPattern
 
@@ -87,35 +89,42 @@ class TestSimpleAutomaton(TestCase):
         return variable_collection, r, f1, f2, f3a, f3b, f5
 
     def test_simple_transitions(self):
+        smt_env = Environment()
         variable_collection, r, f1, f2, f3a, f3b, f5 = self.__get_aut_easy()
         # test general automaton layout
-        req_belonging_to_r = AAutomatonPattern.get_hull(f1, [f for f in r.formalizations.values()], variable_collection)
+        req_belonging_to_r = AAutomatonPattern.get_hull(
+            smt_env, f1, [f for f in r.formalizations.values()], variable_collection
+        )
         aut = {f1, f2, f3a, f3b}
         self.assertSetEqual(aut, set(req_belonging_to_r))
 
     def test_initial_edge(self):
+        smt_env = Environment()
         variable_collection, r, f1, f2, f3a, f3b, f5 = self.__get_aut_easy()
         # test general automaton layout
-        req_belonging_to_r = AAutomatonPattern.get_hull(f1, [f for f in r.formalizations.values()], variable_collection)
+        req_belonging_to_r = AAutomatonPattern.get_hull(
+            smt_env, f1, [f for f in r.formalizations.values()], variable_collection
+        )
         aut = {f1, f2, f3a, f3b}
         # test formula generation
         formal_f3a = f3a.scoped_pattern.get_patternish().get_instanciated_countertraces(
-            f3a.scoped_pattern.scope, f3a, aut, variable_collection
+            smt_env, f3a.scoped_pattern.scope, f3a, aut, variable_collection
         )
         self.assertIsNotNone(formal_f3a)
         # States A and B (1 and 2) are initial.
-        self.assertIn(r"(= states 1)", formal_f3a[0].dc_phases[0].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(= states 2)", formal_f3a[0].dc_phases[0].invariant.to_smtlib(daggify=False))
+        self.assertIn(r"(states = 1)", formal_f3a[0].dc_phases[0].invariant.serialize())
+        self.assertIn(r"(states = 2)", formal_f3a[0].dc_phases[0].invariant.serialize())
 
     def test_edge_simple(self):
+        smt_env = Environment()
         variable_collection, r, f1, f2, f3a, f3b, f5 = self.__get_aut_easy()
         aut = {f1, f2, f3a, f3b}
 
         formal_f1 = f1.scoped_pattern.get_patternish().get_instanciated_countertraces(
-            f1.scoped_pattern.scope, f1, aut, variable_collection
+            smt_env, f1.scoped_pattern.scope, f1, aut, variable_collection
         )
         self.assertIsNotNone(formal_f1)
-        self.assertIn(r"(= states 1)", formal_f1[0].dc_phases[1].invariant.to_smtlib(daggify=False))
-        self.assertNotIn(r"(= states 2)", formal_f1[0].dc_phases[1].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(= states 1)", formal_f1[0].dc_phases[2].invariant.to_smtlib(daggify=False))
-        self.assertIn(r"(= states 2)", formal_f1[0].dc_phases[2].invariant.to_smtlib(daggify=False))
+        self.assertIn(r"(states = 1)", formal_f1[0].dc_phases[1].invariant.serialize())
+        self.assertNotIn(r"(states = 2)", formal_f1[0].dc_phases[1].invariant.serialize())
+        self.assertIn(r"(states = 1)", formal_f1[0].dc_phases[2].invariant.serialize())
+        self.assertIn(r"(states = 2)", formal_f1[0].dc_phases[2].invariant.serialize())

--- a/hanfor/tests/test_csv_parsing_regression.py
+++ b/hanfor/tests/test_csv_parsing_regression.py
@@ -1,7 +1,3 @@
-"""
-TODO: Add description here
-"""
-
 from app import app
 import os
 import shutil

--- a/hanfor/tests/test_pea_operations.py
+++ b/hanfor/tests/test_pea_operations.py
@@ -1,50 +1,57 @@
 from typing import Tuple
 from unittest import TestCase
 
-from pysmt.typing import REAL
+from pysmt.environment import Environment
 
 from lib_pea.countertrace import CountertraceTransformer
-from lib_pea.countertrace_to_pea import build_automaton
+from lib_pea.countertrace_to_pea import PeaBuilder
 from lib_pea.pea import Pea
 from lib_pea.utils import get_countertrace_parser
-from tests.test_req_simulator.test_counter_trace import testcases
-
-from pysmt.shortcuts import FALSE, And, Symbol, simplify
-
-INITIAL_P = ({"P": Symbol("P")}, "⌈!P⌉;true")
-ALWAYS_NOT_P = ({"P": Symbol("P")}, "true;⌈P⌉;true")
-
-DBLB_1 = ({"P": Symbol("P"), "R": Symbol("R"), "T": Symbol("T", REAL)}, "true;⌈P⌉;true;⌈!R⌉;⌈R⌉ ∧ ℓ < T;⌈!R⌉;true")
-DBLB_2 = (
-    {"P": Symbol("P"), "R": Symbol("R"), "T": Symbol("T", REAL)},
-    "true;⌈P⌉;true;⌈(! R)⌉;⌈R⌉ ∧ ℓ < T;⌈(! R)⌉;true",
-)
 
 
 class TestPhaseAutomatonOperations(TestCase):
 
+    def setUp(self):
+        self.env = Environment()
+        self.mgr = self.env.formula_manager
+        self.tm = self.env.type_manager
+
+        self.INITIAL_P = ({"P": self.mgr.Symbol("P")}, "⌈!P⌉;true")
+        self.ALWAYS_NOT_P = ({"P": self.mgr.Symbol("P")}, "true;⌈P⌉;true")
+
+        self.DBLB_1 = (
+            {"P": self.mgr.Symbol("P"), "R": self.mgr.Symbol("R"), "T": self.mgr.Symbol("T", self.tm.REAL())},
+            "true;⌈P⌉;true;⌈!R⌉;⌈R⌉ ∧ ℓ < T;⌈!R⌉;true",
+        )
+        self.DBLB_2 = (
+            {"P": self.mgr.Symbol("P"), "R": self.mgr.Symbol("R"), "T": self.mgr.Symbol("T", self.tm.REAL())},
+            "true;⌈P⌉;true;⌈(! R)⌉;⌈R⌉ ∧ ℓ < T;⌈(! R)⌉;true",
+        )
+
+        self.solver = self.env.factory.Solver()
+
     def test_identity(self):
-        a1 = self.__get_automaton(ALWAYS_NOT_P)
-        a2 = self.__get_automaton(ALWAYS_NOT_P)
-        r = a1.intersect(a2)
+        a1 = self.__get_automaton(self.ALWAYS_NOT_P)
+        a2 = self.__get_automaton(self.ALWAYS_NOT_P)
+        r = a1.intersect(a2, self.env, self.solver)
         print(r)
         # TODO check
 
     def test_empty(self):
-        a1 = self.__get_automaton(INITIAL_P)
-        a2 = self.__get_automaton(ALWAYS_NOT_P)
-        r = a1.intersect(a2)
+        a1 = self.__get_automaton(self.INITIAL_P)
+        a2 = self.__get_automaton(self.ALWAYS_NOT_P)
+        r = a1.intersect(a2, self.env, self.solver)
         print(r)
         # TODO check
 
     def test_large(self):
-        a1 = self.__get_automaton(DBLB_1)
-        a2 = self.__get_automaton(DBLB_2)
-        r = a1.intersect(a2)
+        a1 = self.__get_automaton(self.DBLB_1)
+        a2 = self.__get_automaton(self.DBLB_2)
+        r = a1.intersect(a2, self.env, self.solver)
         print(r)
         pass
 
     def __get_automaton(self, test: Tuple[dict, str]) -> Pea:
         expressions, ct_str = test
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
-        return build_automaton(ct)
+        ct = CountertraceTransformer(self.env, expressions).transform(get_countertrace_parser().parse(ct_str))
+        return PeaBuilder(self.env).build_automaton(ct)

--- a/hanfor/tests/test_quick_checks/test_poor_mans_complete.py
+++ b/hanfor/tests/test_quick_checks/test_poor_mans_complete.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from pysmt.environment import Environment
+
 from lib_core.data import Variable, Requirement, ScopedPattern, Pattern, Formalization
 from lib_core.scopes import Scope
 from quickchecks.check_poormanscomplete import PoorMansComplete, CompletenessCheckOutcome
@@ -19,22 +21,31 @@ class TestPoorMansComplete(TestCase):
         req = Requirement("test_1", "I am a requirement.", "req", dict(), 3)
         f = Formalization(0)
         f.scoped_pattern = ScopedPattern(Scope.GLOBALLY, Pattern(name="BoundedResponse"))
-        f.expressions_mapping = {"R": Mock_Expression(expr1), "S": Mock_Expression(expr2), "T": Mock_Expression(bound)}
+        # noinspection PyTypeChecker
+        f.expressions_mapping = {
+            "R": Mock_Expression(expr1),
+            "S": Mock_Expression(expr2),
+            "T": Mock_Expression(bound),
+        }
         req.formalizations[0] = f
         return req
 
+    @staticmethod
     def __instantiate_universality(name: str, expr1: str) -> Requirement:
         req = Requirement("test_1", "I am a requirement.", "req", dict(), 3)
         req.formalizations[0] = TestPoorMansComplete.__formalisation_universality(expr1)
         return req
 
+    @staticmethod
     def __formalisation_universality(expr1: str) -> Formalization:
         f = Formalization(0)
         f.scoped_pattern = ScopedPattern(Scope.GLOBALLY, Pattern(name="Universality"))
+        # noinspection PyTypeChecker
         f.expressions_mapping = {"R": Mock_Expression(expr1)}
         return f
 
     def test_incomplete_without_env(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "b": Variable("b", "int", None),
@@ -44,13 +55,14 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && b < 5", "b > 6", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && b < 5", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE_UNCONSTRAINT}
         self.assertIn("b", b_result)
         self.assertIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_incomplete_with_env_bool(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -59,15 +71,16 @@ class TestPoorMansComplete(TestCase):
         vars["c"].constraints[0] = TestPoorMansComplete.__formalisation_universality("c > 7")
         reqs = [
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
-            TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
+            TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7 && !a", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE_UNCONSTRAINT}
         self.assertIn("d", b_result)
         self.assertNotIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_incomplete_with_env(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -78,13 +91,14 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c >= 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 10", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE}
         self.assertNotIn("d", b_result)
         self.assertIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_incomplete_with_env_cmplx(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -99,7 +113,7 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c >= 22 && x == 0 ", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 11", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE}
         self.assertNotIn("d", b_result)
         self.assertIn("c", b_result)
@@ -107,6 +121,7 @@ class TestPoorMansComplete(TestCase):
         self.assertIn("x", b_result)
 
     def test_incomplete_with_env_int(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -117,13 +132,14 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE_UNCONSTRAINT}
         self.assertNotIn("d", b_result)
         self.assertIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_incomplete_with_env_neg(self):
+        smt_env = Environment()
         vars = {
             "c": Variable("c", "int", None),
         }
@@ -133,11 +149,12 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "c == 4", "c > 22", "5.0"),
             # TestPoorMansComplete.__instantiate_bound_response("req2", "c < 1000", "c > -33", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE}
         self.assertIn("c", b_result)
 
     def test_incomplete_with_env_univ(self):
+        smt_env = Environment()
         vars = {
             "c": Variable("c", "int", None),
         }
@@ -145,13 +162,14 @@ class TestPoorMansComplete(TestCase):
         reqs = [
             TestPoorMansComplete.__instantiate_bound_response("req1", "c != -4", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req1", "c != -5", "c > 22", "5.0"),
-            # TestPoorMansComplete.__instantiate_bound_response("req2", "c < 1000", "c > -33", "5.0"),
+            TestPoorMansComplete.__instantiate_bound_response("req2", "c < 1000", "c > -33", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE}
         self.assertNotIn("c", b_result)
 
     def test_incomplete_with_env_ok(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -163,13 +181,14 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.INCOMPLETE}
         self.assertNotIn("d", b_result)
         self.assertNotIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_env_violation_int(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -180,13 +199,14 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.ENV_VIOLATED}
         self.assertNotIn("d", b_result)
         self.assertIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_env_violation_bool(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -197,13 +217,13 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.ENV_VIOLATED}
-        self.assertIn("d", b_result)
         self.assertNotIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_env_violation_all(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -215,13 +235,13 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.ENV_VIOLATED}
-        self.assertIn("d", b_result)
         self.assertIn("c", b_result)
         self.assertNotIn("a", b_result)
 
     def test_env_violation_none(self):
+        smt_env = Environment()
         vars = {
             "a": Variable("a", "bool", None),
             "d": Variable("d", "bool", None),
@@ -233,7 +253,7 @@ class TestPoorMansComplete(TestCase):
             TestPoorMansComplete.__instantiate_bound_response("req1", "a && d", "c > 22", "5.0"),
             TestPoorMansComplete.__instantiate_bound_response("req2", "!a && d", "c > 7", "5.0"),
         ]
-        results = PoorMansComplete().run(reqs, set(vars.values()))
+        results = PoorMansComplete(smt_env).run(reqs, set(vars.values()))
         b_result = {r.var: r for r in results if r.outcome == CompletenessCheckOutcome.ENV_VIOLATED}
         self.assertNotIn("d", b_result)
         self.assertNotIn("c", b_result)

--- a/hanfor/tests/test_req_simulator/test_boogie_pysmt_transformer.py
+++ b/hanfor/tests/test_req_simulator/test_boogie_pysmt_transformer.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from parameterized import parameterized
+from pysmt.environment import Environment
 
 from lib_core import boogie_parsing
 from lib_core.data import Variable
@@ -33,5 +34,5 @@ class TestBoogiePysmtTransformer(TestCase):
         ]
     )
     def test_int_expressions(self, test_input: str, expected: str):
-        actual = str(BoogiePysmtTransformer(self.variables).transform(parser.parse(test_input)))
+        actual = str(BoogiePysmtTransformer(Environment(), self.variables).transform(parser.parse(test_input)))
         self.assertEqual(expected, actual, msg="Error while transforming boogie expression to pysmt formula.")

--- a/hanfor/tests/test_req_simulator/test_counter_trace.py
+++ b/hanfor/tests/test_req_simulator/test_counter_trace.py
@@ -1,127 +1,153 @@
-from collections import namedtuple
-from unittest import TestCase
-
-from parameterized import parameterized
+from pysmt.environment import Environment
 from pysmt.fnode import FNode
-from pysmt.shortcuts import Symbol, FALSE, And, Equals, Int, Real
-from pysmt.typing import REAL, INT
-
-from lib_pea.countertrace import CountertraceTransformer
-from lib_pea.utils import get_countertrace_parser
-
-Test = namedtuple("Test", "expressions ct_str expected")
-
-testcases = {
-    "false": Test({"P": FALSE()}, "⌈P⌉;true", "⌈False⌉;True"),
-    "true": Test({}, "true;true", "True;True"),
-    "true_lower_bound_empty": Test({"T": Symbol("T", REAL)}, "true ∧ ℓ >₀ T;true", "True ∧ ℓ >₀ T;True"),
-    "true_lower_bound": Test({"T": Symbol("T", REAL)}, "true ∧ ℓ > T;true", "True ∧ ℓ > T;True"),
-    "absence_globally": Test({"R": Symbol("R")}, "true;⌈R⌉;true", "True;⌈R⌉;True"),
-    "absence_before": Test({"P": Symbol("P"), "R": Symbol("R")}, "⌈!P⌉;⌈(!P && R)⌉;true", "⌈(! P)⌉;⌈((! P) & R)⌉;True"),
-    "absence_after": Test({"P": Symbol("P"), "R": Symbol("R")}, "true;⌈P⌉;true;⌈R⌉;true", "True;⌈P⌉;True;⌈R⌉;True"),
-    "absence_between": Test(
-        {"P": Symbol("P"), "Q": Symbol("Q"), "R": Symbol("R")},
-        "true;⌈(P && !Q)⌉;⌈!Q⌉;⌈(!Q && R)⌉;⌈!Q⌉;⌈Q⌉;true",
-        "True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈((! Q) & R)⌉;⌈(! Q)⌉;⌈Q⌉;True",
-    ),
-    "absence_after_until": Test(
-        {"P": Symbol("P"), "Q": Symbol("Q"), "R": Symbol("R")},
-        "true;⌈P⌉;⌈!Q⌉;⌈(!Q && R)⌉;true",
-        "True;⌈P⌉;⌈(! Q)⌉;⌈((! Q) & R)⌉;True",
-    ),
-    "duration_bound_l_globally": Test(
-        {"R": Symbol("R"), "T": Symbol("T", REAL)},
-        "true;⌈!R⌉;⌈R⌉ ∧ ℓ < T;⌈!R⌉;true",
-        "True;⌈(! R)⌉;⌈R⌉ ∧ ℓ < T;⌈(! R)⌉;True",
-    ),
-    "duration_bound_l_before": Test(
-        {"P": Symbol("P"), "R": Symbol("R"), "T": Symbol("T", REAL)},
-        "⌈!P⌉;⌈(!P && !R)⌉;⌈(!P && R)⌉ ∧ ℓ < T;⌈(!P && !R)⌉;true",
-        "⌈(! P)⌉;⌈((! P) & (! R))⌉;⌈((! P) & R)⌉ ∧ ℓ < T;⌈((! P) & (! R))⌉;True",
-    ),
-    "duration_bound_l_after": Test(
-        {"P": Symbol("P"), "R": Symbol("R"), "T": Symbol("T", REAL)},
-        "true;⌈P⌉;true;⌈!R⌉;⌈R⌉ ∧ ℓ < T;⌈!R⌉;true",
-        "True;⌈P⌉;True;⌈(! R)⌉;⌈R⌉ ∧ ℓ < T;⌈(! R)⌉;True",
-    ),
-    "duration_bound_l_between": Test(
-        {"P": Symbol("P"), "Q": Symbol("Q"), "R": Symbol("R"), "T": Symbol("T", REAL)},
-        "true;⌈(P && !Q)⌉;⌈!Q⌉;⌈(!Q && !R)⌉;⌈(!Q && R)⌉ ∧ ℓ < T;⌈(!Q && !R)⌉;⌈!Q⌉;⌈Q⌉;true",
-        "True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈((! Q) & (! R))⌉;⌈((! Q) & R)⌉ ∧ ℓ < T;⌈((! Q) & (! R))⌉;⌈(! Q)⌉;⌈Q⌉;True",
-    ),
-    "duration_bound_l_after_until": Test(
-        {"P": Symbol("P"), "Q": Symbol("Q"), "R": Symbol("R"), "T": Symbol("T", REAL)},
-        "true;⌈P⌉;⌈!Q⌉;⌈(!Q && !R)⌉;⌈(!Q && R)⌉ ∧ ℓ < T;⌈(!Q && !R)⌉;true",
-        "True;⌈P⌉;⌈(! Q)⌉;⌈((! Q) & (! R))⌉;⌈((! Q) & R)⌉ ∧ ℓ < T;⌈((! Q) & (! R))⌉;True",
-    ),
-    "duration_bound_u_globally": Test(
-        {"R": Symbol("R"), "T": Symbol("T", REAL)}, "true;⌈R⌉ ∧ ℓ ≥ T;true", "True;⌈R⌉ ∧ ℓ ≥ T;True"
-    ),
-    "response_delay_globally": Test(
-        {"R": Symbol("R"), "S": Symbol("S"), "T": Symbol("T", REAL)},
-        "true;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true",
-        "True;⌈(R & (! S))⌉;⌈(! S)⌉ ∧ ℓ > T;True",
-    ),
-    "response_delay_before": Test(
-        {"P": Symbol("P"), "R": Symbol("R"), "S": Symbol("S"), "T": Symbol("T", REAL)},
-        "⌈!P⌉;⌈(!P && (R && !S))⌉;⌈(!P && !S)⌉ ∧ ℓ > T;true",
-        "⌈(! P)⌉;⌈((! P) & (R & (! S)))⌉;⌈((! P) & (! S))⌉ ∧ ℓ > T;True",
-    ),
-    "response_delay_after": Test(
-        {"P": Symbol("P"), "R": Symbol("R"), "S": Symbol("S"), "T": Symbol("T", REAL)},
-        "true;⌈P⌉;true;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true",
-        "True;⌈P⌉;True;⌈(R & (! S))⌉;⌈(! S)⌉ ∧ ℓ > T;True",
-    ),
-    "response_delay_between": Test(
-        {"P": Symbol("P"), "Q": Symbol("Q"), "R": Symbol("R"), "S": Symbol("S"), "T": Symbol("T", REAL)},
-        "true;⌈(P && !Q)⌉;⌈!Q⌉;⌈(!Q && (R && !S))⌉;⌈(!Q && !S)⌉ ∧ ℓ > T;⌈!Q⌉;⌈Q⌉;true",
-        "True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈((! Q) & (R & (! S)))⌉;⌈((! Q) & (! S))⌉ ∧ ℓ > T;⌈(! Q)⌉;⌈Q⌉;True",
-    ),
-    "response_delay_after_until": Test(
-        {"P": Symbol("P"), "Q": Symbol("Q"), "R": Symbol("R"), "S": Symbol("S"), "T": Symbol("T", REAL)},
-        "true;⌈P⌉;⌈!Q⌉;⌈(!Q && (R && !S))⌉;⌈(!Q && !S)⌉ ∧ ℓ > T;true",
-        "True;⌈P⌉;⌈(! Q)⌉;⌈((! Q) & (R & (! S)))⌉;⌈((! Q) & (! S))⌉ ∧ ℓ > T;True",
-    ),
-    "universality_globally": Test(
-        {"P": And(Equals(Symbol("int", INT), Int(1)), Equals(Symbol("real", REAL), Real(1.0)))},
-        "true;⌈P⌉;true",
-        "True;⌈((int = 1) & (real = 1.0))⌉;True",
-    ),
-}
+from z3 import Symbol
 
 
-class TestCounterTrace(TestCase):
-    # TODO: Obsolete.
-    """
-    @parameterized.expand([
-        ('BndResponsePatternUT', 'GLOBALLY',
-         {'R': Symbol('R'), 'S': Symbol('S'), 'T': Symbol('T', REAL)},
-         'True;⌈(R & (! S))⌉;⌈(! S)⌉ ∧ ℓ > T;True'),
-
-        ('BndResponsePatternUT', 'BEFORE',
-         {'P': Symbol('P'), 'R': Symbol('R'), 'S': Symbol('S'), 'T': Symbol('T', REAL)},
-         '⌈(! P)⌉;⌈(((! P) & R) & (! S))⌉;⌈((! P) & (! S))⌉ ∧ ℓ > T;True'),
-
-        ('BndResponsePatternUT', 'AFTER',
-         {'P': Symbol('P'), 'R': Symbol('R'), 'S': Symbol('S'), 'T': Symbol('T', REAL)},
-         'True;⌈P⌉;True;⌈(R & (! S))⌉;⌈(! S)⌉ ∧ ℓ > T;True'),
-
-        ('BndResponsePatternUT', 'BETWEEN',
-         {'P': Symbol('P'), 'Q': Symbol('Q'), 'R': Symbol('R'), 'S': Symbol('S'), 'T': Symbol('T', REAL)},
-         'True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈(((! Q) & R) & (! S))⌉;⌈((! Q) & (! S))⌉ ∧ ℓ > T;⌈(! Q)⌉;⌈Q⌉;True'),
-
-        ('BndResponsePatternUT', 'AFTER_UNTIL',
-         {'P': Symbol('P'), 'Q': Symbol('Q'), 'R': Symbol('R'), 'S': Symbol('S'), 'T': Symbol('T', REAL)},
-         'True;⌈P⌉;⌈(! Q)⌉;⌈(((! Q) & R) & (! S))⌉;⌈((! Q) & (! S))⌉ ∧ ℓ > T;True'),
-    ])
-    def test_bnd_response_pattern_ut(self, pattern: str, scope: str, expressions: dict[str, FNode], expected: str):
-        actual = create_counter_trace(scope, pattern, expressions)
-        self.assertEqual(expected, str(actual), msg="Error while creating counter trace.")
-    """
-
-    @parameterized.expand([(k, *v) for k, v in testcases.items()])
-    def test_counter_trace(self, name, expressions: dict[str, FNode], counter_trace: str, expected: str):
-        lark_tree = get_countertrace_parser().parse(counter_trace)
-        actual = CountertraceTransformer(expressions).transform(lark_tree)
-        self.assertEqual(expected, str(actual), msg="Error while parsing counter trace.")
-        # Image.open(BytesIO(pydot__tree_to_graph(lark_tree).create_png())).show()
+def pattern_cases(smt_env: Environment, name) -> tuple[dict[str, FNode], str, str]:
+    """Returns test data in the form:
+    - Dict of expressions
+    - Ct formula to be tested
+    - expected result (also as a ct formula)"""
+    fmgr = smt_env.formula_manager
+    tmgr = smt_env.type_manager
+    match name:
+        case "false":
+            return {"P": fmgr.FALSE()}, "⌈P⌉;true", "⌈FALSE⌉;True"
+        case "true":
+            return {}, "true;true", "True;True"
+        case "true_lower_bound_empty":
+            return {"T": fmgr.Symbol("T", tmgr.REAL())}, "true ∧ ℓ >₀ T;true", "True ∧ ℓ >₀ T;True"
+        case "true_lower_bound":
+            return {"T": fmgr.Symbol("T", tmgr.REAL())}, "true ∧ ℓ > T;true", "True ∧ ℓ > T;True"
+        case "absence_globally":
+            return {"R": fmgr.Symbol("R")}, "true;⌈R⌉;true", "True;⌈R⌉;True"
+        case "absence_before":
+            return (
+                {"P": fmgr.Symbol("P"), "R": fmgr.Symbol("R")},
+                "⌈!P⌉;⌈(!P && R)⌉;true",
+                "⌈(! P)⌉;⌈((! P) & R)⌉;True",
+            )
+        case "absence_after":
+            return {"P": fmgr.Symbol("P"), "R": fmgr.Symbol("R")}, "true;⌈P⌉;true;⌈R⌉;true", "True;⌈P⌉;True;⌈R⌉;True"
+        case "absence_between":
+            return (
+                {"P": fmgr.Symbol("P"), "Q": fmgr.Symbol("Q"), "R": fmgr.Symbol("R")},
+                "true;⌈(P && !Q)⌉;⌈!Q⌉;⌈(!Q && R)⌉;⌈!Q⌉;⌈Q⌉;true",
+                "True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈((! Q) & R)⌉;⌈(! Q)⌉;⌈Q⌉;True",
+            )
+        case "absence_after_until":
+            return (
+                {"P": fmgr.Symbol("P"), "Q": fmgr.Symbol("Q"), "R": fmgr.Symbol("R")},
+                "true;⌈P⌉;⌈!Q⌉;⌈(!Q && R)⌉;true",
+                "True;⌈P⌉;⌈(! Q)⌉;⌈((! Q) & R)⌉;True",
+            )
+        case "duration_bound_l_globally":
+            return (
+                {"R": fmgr.Symbol("R"), "T": fmgr.Symbol("T", tmgr.REAL())},
+                "true;⌈!R⌉;⌈R⌉ ∧ ℓ < T;⌈!R⌉;true",
+                "True;⌈(! R)⌉;⌈R⌉ ∧ ℓ < T;⌈(! R)⌉;True",
+            )
+        case "duration_bound_l_before":
+            return (
+                {"P": fmgr.Symbol("P"), "R": fmgr.Symbol("R"), "T": fmgr.Symbol("T", tmgr.REAL())},
+                "⌈!P⌉;⌈(!P && !R)⌉;⌈(!P && R)⌉ ∧ ℓ < T;⌈(!P && !R)⌉;true",
+                "⌈(! P)⌉;⌈((! P) & (! R))⌉;⌈((! P) & R)⌉ ∧ ℓ < T;⌈((! P) & (! R))⌉;True",
+            )
+        case "duration_bound_l_after":
+            return (
+                {"P": fmgr.Symbol("P"), "R": fmgr.Symbol("R"), "T": fmgr.Symbol("T", tmgr.REAL())},
+                "true;⌈P⌉;true;⌈!R⌉;⌈R⌉ ∧ ℓ < T;⌈!R⌉;true",
+                "True;⌈P⌉;True;⌈(! R)⌉;⌈R⌉ ∧ ℓ < T;⌈(! R)⌉;True",
+            )
+        case "duration_bound_l_between":
+            return (
+                {
+                    "P": fmgr.Symbol("P"),
+                    "Q": fmgr.Symbol("Q"),
+                    "R": fmgr.Symbol("R"),
+                    "T": fmgr.Symbol("T", tmgr.REAL()),
+                },
+                "true;⌈(P && !Q)⌉;⌈!Q⌉;⌈(!Q && !R)⌉;⌈(!Q && R)⌉ ∧ ℓ < T;⌈(!Q && !R)⌉;⌈!Q⌉;⌈Q⌉;true",
+                "True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈((! Q) & (! R))⌉;⌈((! Q) & R)⌉ ∧ ℓ < T;⌈((! Q) & (! R))⌉;⌈(! Q)⌉;⌈Q⌉;True",
+            )
+        case "duration_bound_l_after_until":
+            return (
+                {
+                    "P": fmgr.Symbol("P"),
+                    "Q": fmgr.Symbol("Q"),
+                    "R": fmgr.Symbol("R"),
+                    "T": fmgr.Symbol("T", tmgr.REAL()),
+                },
+                "true;⌈P⌉;⌈!Q⌉;⌈(!Q && !R)⌉;⌈(!Q && R)⌉ ∧ ℓ < T;⌈(!Q && !R)⌉;true",
+                "True;⌈P⌉;⌈(! Q)⌉;⌈((! Q) & (! R))⌉;⌈((! Q) & R)⌉ ∧ ℓ < T;⌈((! Q) & (! R))⌉;True",
+            )
+        case "duration_bound_u_globally":
+            return (
+                {"R": fmgr.Symbol("R"), "T": fmgr.Symbol("T", tmgr.REAL())},
+                "true;⌈R⌉ ∧ ℓ ≥ T;true",
+                "True;⌈R⌉ ∧ ℓ ≥ T;True",
+            )
+        case "response_delay_globally":
+            return (
+                {"R": fmgr.Symbol("R"), "S": fmgr.Symbol("S"), "T": fmgr.Symbol("T", tmgr.REAL())},
+                "true;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true",
+                "True;⌈(R & (! S))⌉;⌈(! S)⌉ ∧ ℓ > T;True",
+            )
+        case "response_delay_before":
+            return (
+                {
+                    "P": fmgr.Symbol("P"),
+                    "R": fmgr.Symbol("R"),
+                    "S": fmgr.Symbol("S"),
+                    "T": fmgr.Symbol("T", tmgr.REAL()),
+                },
+                "⌈!P⌉;⌈(!P && (R && !S))⌉;⌈(!P && !S)⌉ ∧ ℓ > T;true",
+                "⌈(! P)⌉;⌈((! P) & (R & (! S)))⌉;⌈((! P) & (! S))⌉ ∧ ℓ > T;True",
+            )
+        case "response_delay_after":
+            return (
+                {
+                    "P": fmgr.Symbol("P"),
+                    "R": fmgr.Symbol("R"),
+                    "S": fmgr.Symbol("S"),
+                    "T": fmgr.Symbol("T", tmgr.REAL()),
+                },
+                "true;⌈P⌉;true;⌈(R && !S)⌉;⌈!S⌉ ∧ ℓ > T;true",
+                "True;⌈P⌉;True;⌈(R & (! S))⌉;⌈(! S)⌉ ∧ ℓ > T;True",
+            )
+        case "response_delay_between":
+            return (
+                {
+                    "P": fmgr.Symbol("P"),
+                    "Q": fmgr.Symbol("Q"),
+                    "R": fmgr.Symbol("R"),
+                    "S": fmgr.Symbol("S"),
+                    "T": fmgr.Symbol("T", tmgr.REAL()),
+                },
+                "true;⌈(P && !Q)⌉;⌈!Q⌉;⌈(!Q && (R && !S))⌉;⌈(!Q && !S)⌉ ∧ ℓ > T;⌈!Q⌉;⌈Q⌉;true",
+                "True;⌈(P & (! Q))⌉;⌈(! Q)⌉;⌈((! Q) & (R & (! S)))⌉;⌈((! Q) & (! S))⌉ ∧ ℓ > T;⌈(! Q)⌉;⌈Q⌉;True",
+            )
+        case "response_delay_after_until":
+            return (
+                {
+                    "P": fmgr.Symbol("P"),
+                    "Q": fmgr.Symbol("Q"),
+                    "R": fmgr.Symbol("R"),
+                    "S": fmgr.Symbol("S"),
+                    "T": fmgr.Symbol("T", tmgr.REAL()),
+                },
+                "true;⌈P⌉;⌈!Q⌉;⌈(!Q && (R && !S))⌉;⌈(!Q && !S)⌉ ∧ ℓ > T;true",
+                "True;⌈P⌉;⌈(! Q)⌉;⌈((! Q) & (R & (! S)))⌉;⌈((! Q) & (! S))⌉ ∧ ℓ > T;True",
+            )
+        case "universality_globally":
+            return (
+                {
+                    "P": fmgr.And(
+                        fmgr.Equals(fmgr.Symbol("int", tmgr.INT()), fmgr.Int(1)),
+                        fmgr.Equals(fmgr.Symbol("real", tmgr.REAL()), fmgr.Real(1.0)),
+                    )
+                },
+                "true;⌈P⌉;true",
+                "True;⌈((int = 1) & (real = 1.0))⌉;True",
+            )
+    raise NotImplementedError(f"Testcase {name} not existing")

--- a/hanfor/tests/test_req_simulator/test_phase_event_automaton.py
+++ b/hanfor/tests/test_req_simulator/test_phase_event_automaton.py
@@ -1,311 +1,404 @@
 from unittest import TestCase
 
-from pysmt.shortcuts import Symbol, And, LT, GE, Or, LE, TRUE, Not
-from pysmt.typing import REAL
+from pysmt.environment import Environment
 
 from lib_pea.countertrace import CountertraceTransformer
-from lib_pea.pea import PhaseSetsPea
-from lib_pea.transition import PhaseSetsTransition
+from lib_pea.countertrace_to_pea import PeaBuilder
 from lib_pea.location import PhaseSetsLocation
+from lib_pea.pea import PhaseSetsPea
 from lib_pea.phase_sets import PhaseSets
-from lib_pea.countertrace_to_pea import build_automaton
+from lib_pea.transition import PhaseSetsTransition
 from lib_pea.utils import get_countertrace_parser
-from tests.test_req_simulator.test_counter_trace import testcases
+from tests.test_req_simulator.test_counter_trace import pattern_cases
 
 
 class TestPhaseEventAutomaton(TestCase):
     def test_false(self):
-        expressions, ct_str, _ = testcases["false"]
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "false")
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
 
         # ct0_st
-        p1_invariant = TRUE()
-        p1 = PhaseSetsLocation(p1_invariant, TRUE(), PhaseSets())
+        p1_invariant = fmgr.TRUE()
+        p1 = PhaseSetsLocation(smt_env, p1_invariant, fmgr.TRUE(), PhaseSets())
         # ct0_st
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, p1_invariant))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, p1_invariant))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, p1_invariant))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, p1_invariant))
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_true(self):
-        expressions, ct_str, _ = testcases["true"]
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "true")
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_true_lower_bound_empty(self):
-        expressions, ct_str, _ = testcases["true_lower_bound_empty"]
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "true_lower_bound_empty")
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_true_lower_bound(self):
-        expressions, ct_str, _ = testcases["true_lower_bound"]
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "true_lower_bound")
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
-        T, c0 = expressions["T"], Symbol("c0", REAL)
+        expected = PhaseSetsPea(smt_env, ct)
+        T, c0 = expressions["T"], fmgr.Symbol("c0", tmgr.REAL())
 
         # ct0_st0W
-        p1_invariant = TRUE()
-        p1 = PhaseSetsLocation(p1_invariant, LE(c0, T), PhaseSets(wait=frozenset({0}), active=frozenset({0})))
+        p1_invariant = fmgr.TRUE()
+        p1 = PhaseSetsLocation(
+            smt_env, p1_invariant, fmgr.LE(c0, T), PhaseSets(wait=frozenset({0}), active=frozenset({0}))
+        )
         # ct0_st0W
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, p1_invariant, frozenset({"c0"})))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, And(p1_invariant, LT(c0, T))))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, p1_invariant, frozenset({"c0"})))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, fmgr.And(p1_invariant, fmgr.LT(c0, T))))
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_absence_globally(self):
-        expressions, ct_str, _ = testcases["absence_globally"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "absence_globally")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
         R = expressions["R"]
         R_ = expressions_["R_"]
         R_ = R
 
         # ct0_st0
-        p1 = PhaseSetsLocation(Not(R), TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(smt_env, fmgr.Not(R), fmgr.TRUE(), PhaseSets(active=frozenset({0})))
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, Not(R_)))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, Not(R_)))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, fmgr.Not(R_)))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, fmgr.Not(R_)))
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_absence_before(self):
-        expressions, ct_str, _ = testcases["absence_before"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "absence_before")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
         P, R = expressions["P"], expressions["R"]
         P_, R_ = expressions_["P_"], expressions_["R_"]
         P_, R_ = P, R
 
         # ct0_st0
-        p1 = PhaseSetsLocation(And(Not(P), Not(R)), TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(
+            smt_env, fmgr.And(fmgr.Not(P), fmgr.Not(R)), fmgr.TRUE(), PhaseSets(active=frozenset({0}))
+        )
         # ct0_st
-        p2 = PhaseSetsLocation(TRUE(), TRUE(), PhaseSets())
+        p2 = PhaseSetsLocation(smt_env, fmgr.TRUE(), fmgr.TRUE(), PhaseSets())
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, And(Not(P_), Not(R_))))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, And(Not(P_), Not(R_))))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p2, P_))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, fmgr.And(fmgr.Not(P_), fmgr.Not(R_))))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, fmgr.And(fmgr.Not(P_), fmgr.Not(R_))))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p2, P_))
         # ct0_st
-        expected.transitions[None].add(PhaseSetsTransition(None, p2, P_))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p2, TRUE()))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p2, P_))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p2, fmgr.TRUE()))
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_absence_after(self):
-        expressions, ct_str, _ = testcases["absence_after"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "absence_after")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
         P, R = expressions["P"], expressions["R"]
         P_, R_ = expressions_["P_"], expressions_["R_"]
         P_, R_ = P, R
 
         # ct0_st0
-        p1 = PhaseSetsLocation(Not(P), TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(smt_env, fmgr.Not(P), fmgr.TRUE(), PhaseSets(active=frozenset({0})))
         # ct0_st012
-        p2 = PhaseSetsLocation(And(P, Not(R)), TRUE(), PhaseSets(active=frozenset({0, 1, 2})))
+        p2 = PhaseSetsLocation(smt_env, fmgr.And(P, fmgr.Not(R)), fmgr.TRUE(), PhaseSets(active=frozenset({0, 1, 2})))
         # ct0_st02
-        p3 = PhaseSetsLocation(And(Not(P), Not(R)), TRUE(), PhaseSets(active=frozenset({0, 2})))
+        p3 = PhaseSetsLocation(
+            smt_env, fmgr.And(fmgr.Not(P), fmgr.Not(R)), fmgr.TRUE(), PhaseSets(active=frozenset({0, 2}))
+        )
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, Not(P_)))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, Not(P_)))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p2, And(P_, Not(R_))))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, fmgr.Not(P_)))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, fmgr.Not(P_)))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p2, fmgr.And(P_, fmgr.Not(R_))))
         # ct0_st012
-        expected.transitions[None].add(PhaseSetsTransition(None, p2, And(P_, Not(R_))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p2, And(P_, Not(R_))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p3, And(Not(P_), Not(R_))))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p2, fmgr.And(P_, fmgr.Not(R_))))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p2, fmgr.And(P_, fmgr.Not(R_))))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p3, fmgr.And(fmgr.Not(P_), fmgr.Not(R_))))
         # ct0_st02
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p3, And(Not(P_), Not(R_))))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p2, And(P_, Not(R_))))
+        expected.transitions[p3].add(PhaseSetsTransition(smt_env, p3, p3, fmgr.And(fmgr.Not(P_), fmgr.Not(R_))))
+        expected.transitions[p3].add(PhaseSetsTransition(smt_env, p3, p2, fmgr.And(P_, fmgr.Not(R_))))
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_duration_bound_l_pattern_globally(self):
-        expressions, ct_str, _ = testcases["duration_bound_l_globally"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "duration_bound_l_globally")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
-        R, T, c2 = expressions["R"], expressions["T"], Symbol("c2", REAL)
+        expected = PhaseSetsPea(smt_env, ct)
+        R, T, c2 = expressions["R"], expressions["T"], fmgr.Symbol("c2", tmgr.REAL())
         R_ = expressions_["R_"]
         R_ = R
 
         # ct0_st0
-        p1 = PhaseSetsLocation(R, TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(smt_env, R, fmgr.TRUE(), PhaseSets(active=frozenset({0})))
         # ct0_st01
-        p2 = PhaseSetsLocation(Not(R), TRUE(), PhaseSets(active=frozenset({0, 1})))
+        p2 = PhaseSetsLocation(smt_env, fmgr.Not(R), fmgr.TRUE(), PhaseSets(active=frozenset({0, 1})))
         # ct0_st02
-        p3 = PhaseSetsLocation(R, LE(c2, T), PhaseSets(less=frozenset({2}), active=frozenset({0, 2})))
+        p3 = PhaseSetsLocation(smt_env, R, fmgr.LE(c2, T), PhaseSets(less=frozenset({2}), active=frozenset({0, 2})))
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, R_))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, R_))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p2, Not(R_)))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, R_))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, R_))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p2, fmgr.Not(R_)))
         # ct0_st01
-        expected.transitions[None].add(PhaseSetsTransition(None, p2, Not(R_)))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p2, Not(R_)))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p3, R_, frozenset({"c2"})))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p2, fmgr.Not(R_)))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p2, fmgr.Not(R_)))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p3, R_, frozenset({"c2"})))
         # ct0_st02
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p3, And(LT(c2, T), R_)))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p1, And(GE(c2, T), R_)))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p2, And(Or(R_, GE(c2, T)), Not(R_))))
+        expected.transitions[p3].add(PhaseSetsTransition(smt_env, p3, p3, fmgr.And(fmgr.LT(c2, T), R_)))
+        expected.transitions[p3].add(PhaseSetsTransition(smt_env, p3, p1, fmgr.And(fmgr.GE(c2, T), R_)))
+        expected.transitions[p3].add(
+            PhaseSetsTransition(smt_env, p3, p2, fmgr.And(fmgr.Or(R_, fmgr.GE(c2, T)), fmgr.Not(R_)))
+        )
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_duration_bound_u_globally(self):
-        expressions, ct_str, _ = testcases["duration_bound_u_globally"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "duration_bound_u_globally")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
-        R, T, c1 = expressions["R"], expressions["T"], Symbol("c1", REAL)
+        expected = PhaseSetsPea(smt_env, ct)
+        R, T, c1 = expressions["R"], expressions["T"], fmgr.Symbol("c1", tmgr.REAL())
         R_ = expressions_["R_"]
         R_ = R
 
         # ct0_st0
-        p1 = PhaseSetsLocation(Not(R), TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(smt_env, fmgr.Not(R), fmgr.TRUE(), PhaseSets(active=frozenset({0})))
         # ct0_st01X
         p2 = PhaseSetsLocation(
+            smt_env,
             R,
-            LT(c1, T),
+            fmgr.LT(c1, T),
             PhaseSets(gteq=frozenset({1}), wait=frozenset({1}), active=frozenset({0, 1})),
         )
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, Not(R_)))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, Not(R_)))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p2, R_, frozenset({"c1"})))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, fmgr.Not(R_)))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, fmgr.Not(R_)))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p2, R_, frozenset({"c1"})))
         # ct0_st01X
-        expected.transitions[None].add(PhaseSetsTransition(None, p2, R_, frozenset({"c1"})))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p2, And(LT(c1, T), R_)))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p1, And(LT(c1, T), Not(R_))))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p2, R_, frozenset({"c1"})))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p2, fmgr.And(fmgr.LT(c1, T), R_)))
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p1, fmgr.And(fmgr.LT(c1, T), fmgr.Not(R_))))
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_response_delay_globally(self):
-        expressions, ct_str, _ = testcases["response_delay_globally"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "response_delay_globally")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
         R, S, T, c2 = (
             expressions["R"],
             expressions["S"],
             expressions["T"],
-            Symbol("c2", REAL),
+            fmgr.Symbol("c2", tmgr.REAL()),
         )
         R_, S_ = expressions_["R_"], expressions_["S_"]
         S_, R_ = S, R
 
         # ct0_st0
-        p1 = PhaseSetsLocation(Or(S, Not(R)), TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(smt_env, fmgr.Or(S, fmgr.Not(R)), fmgr.TRUE(), PhaseSets(active=frozenset({0})))
         # ct0_st012W
         p2 = PhaseSetsLocation(
-            And(R, Not(S)),
-            LE(c2, T),
+            smt_env,
+            fmgr.And(R, fmgr.Not(S)),
+            fmgr.LE(c2, T),
             PhaseSets(wait=frozenset({2}), active=frozenset({0, 1, 2})),
         )
         # ct0_st02W
         p3 = PhaseSetsLocation(
-            And(Not(R), Not(S)),
-            LE(c2, T),
+            smt_env,
+            fmgr.And(fmgr.Not(R), fmgr.Not(S)),
+            fmgr.LE(c2, T),
             PhaseSets(wait=frozenset({2}), active=frozenset({0, 2})),
         )
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, Or(S_, Not(R_))))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, Or(S_, Not(R_))))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p2, And(R_, Not(S_)), frozenset({"c2"})))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p1, fmgr.Or(S_, fmgr.Not(R_))))
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p1, fmgr.Or(S_, fmgr.Not(R_))))
+        expected.transitions[p1].add(
+            PhaseSetsTransition(smt_env, p1, p2, fmgr.And(R_, fmgr.Not(S_)), frozenset({"c2"}))
+        )
         # ct0_st012W
-        expected.transitions[None].add(PhaseSetsTransition(None, p2, And(R_, Not(S_)), frozenset({"c2"})))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p2, And(LT(c2, T), And(R_, Not(S_)))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p1, And(S_, Or(S_, Not(R_)))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p3, And(LT(c2, T), And(Not(R_), Not(S_)))))
+        expected.transitions[None].add(
+            PhaseSetsTransition(smt_env, None, p2, fmgr.And(R_, fmgr.Not(S_)), frozenset({"c2"}))
+        )
+        expected.transitions[p2].add(
+            PhaseSetsTransition(smt_env, p2, p2, fmgr.And(fmgr.LT(c2, T), fmgr.And(R_, fmgr.Not(S_))))
+        )
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p1, fmgr.And(S_, fmgr.Or(S_, fmgr.Not(R_)))))
+        expected.transitions[p2].add(
+            PhaseSetsTransition(smt_env, p2, p3, fmgr.And(fmgr.LT(c2, T), fmgr.And(fmgr.Not(R_), fmgr.Not(S_))))
+        )
         # ct0_st02W
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p3, And(LT(c2, T), And(Not(R_), Not(S_)))))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p1, And(S_, Or(S_, Not(R_)))))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p2, And(LT(c2, T), And(R_, Not(S_)))))
+        expected.transitions[p3].add(
+            PhaseSetsTransition(smt_env, p3, p3, fmgr.And(fmgr.LT(c2, T), fmgr.And(fmgr.Not(R_), fmgr.Not(S_))))
+        )
+        expected.transitions[p3].add(PhaseSetsTransition(smt_env, p3, p1, fmgr.And(S_, fmgr.Or(S_, fmgr.Not(R_)))))
+        expected.transitions[p3].add(
+            PhaseSetsTransition(smt_env, p3, p2, fmgr.And(fmgr.LT(c2, T), fmgr.And(R_, fmgr.Not(S_))))
+        )
 
-        actual = build_automaton(ct)
+        actual = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")
 
     def test_response_delay_before(self):
-        expressions, ct_str, _ = testcases["response_delay_before"]
-        expressions_ = {k + "_": Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
+        smt_env = Environment()
+        fmgr = smt_env.formula_manager
+        tmgr = smt_env.type_manager
+        expressions, ct_str, _ = pattern_cases(smt_env, "response_delay_before")
+        expressions_ = {k + "_": fmgr.Symbol(v.symbol_name() + "_", v.symbol_type()) for k, v in expressions.items()}
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
 
-        expected = PhaseSetsPea()
+        expected = PhaseSetsPea(smt_env, ct)
         P, R, S, T, c2 = (
             expressions["P"],
             expressions["R"],
             expressions["S"],
             expressions["T"],
-            Symbol("c2", REAL),
+            fmgr.Symbol("c2", tmgr.REAL()),
         )
         P_, R_, S_ = expressions_["P_"], expressions_["R_"], expressions_["S_"]
         P_, R_, S_ = P, R, S
 
         # ct0_st0
-        p1 = PhaseSetsLocation(And(Not(P), Or(S, Not(R))), TRUE(), PhaseSets(active=frozenset({0})))
+        p1 = PhaseSetsLocation(
+            smt_env, fmgr.And(fmgr.Not(P), fmgr.Or(S, fmgr.Not(R))), fmgr.TRUE(), PhaseSets(active=frozenset({0}))
+        )
         # ct0_st012W
         p2 = PhaseSetsLocation(
-            And(Not(P), And(R, Not(S))),
-            LE(c2, T),
+            smt_env,
+            fmgr.And(fmgr.Not(P), fmgr.And(R, fmgr.Not(S))),
+            fmgr.LE(c2, T),
             PhaseSets(wait=frozenset({2}), active=frozenset({0, 1, 2})),
         )
         # ct0_st02W
         p3 = PhaseSetsLocation(
-            And(Not(P), And(Not(R), Not(S))),
-            LE(c2, T),
+            smt_env,
+            fmgr.And(fmgr.Not(P), fmgr.And(fmgr.Not(R), fmgr.Not(S))),
+            fmgr.LE(c2, T),
             PhaseSets(wait=frozenset({2}), active=frozenset({0, 2})),
         )
         # ct0_st
-        p4 = PhaseSetsLocation(TRUE(), TRUE(), PhaseSets())
+        p4 = PhaseSetsLocation(smt_env, fmgr.TRUE(), fmgr.TRUE(), PhaseSets())
 
         # ct0_st0
-        expected.transitions[None].add(PhaseSetsTransition(None, p1, And(Not(P_), Or(S_, Not(R_)))))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p1, And(Not(P_), Or(S_, Not(R_)))))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p2, And(Not(P_), And(R_, Not(S_))), frozenset({"c2"})))
-        expected.transitions[p1].add(PhaseSetsTransition(p1, p4, P_))
+        expected.transitions[None].add(
+            PhaseSetsTransition(smt_env, None, p1, fmgr.And(fmgr.Not(P_), fmgr.Or(S_, fmgr.Not(R_))))
+        )
+        expected.transitions[p1].add(
+            PhaseSetsTransition(smt_env, p1, p1, fmgr.And(fmgr.Not(P_), fmgr.Or(S_, fmgr.Not(R_))))
+        )
+        expected.transitions[p1].add(
+            PhaseSetsTransition(smt_env, p1, p2, fmgr.And(fmgr.Not(P_), fmgr.And(R_, fmgr.Not(S_))), frozenset({"c2"}))
+        )
+        expected.transitions[p1].add(PhaseSetsTransition(smt_env, p1, p4, P_))
         # ct0_st012W
-        expected.transitions[None].add(PhaseSetsTransition(None, p2, And(Not(P_), And(R_, Not(S_))), frozenset({"c2"})))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p2, And(LT(c2, T), And(Not(P_), And(R_, Not(S_))))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p1, And(Or(P_, S_), And(Not(P_), Or(S_, Not(R_))))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p3, And(LT(c2, T), And(Not(P_), And(Not(R_), Not(S_))))))
-        expected.transitions[p2].add(PhaseSetsTransition(p2, p4, P_))
+        expected.transitions[None].add(
+            PhaseSetsTransition(
+                smt_env, None, p2, fmgr.And(fmgr.Not(P_), fmgr.And(R_, fmgr.Not(S_))), frozenset({"c2"})
+            )
+        )
+        expected.transitions[p2].add(
+            PhaseSetsTransition(
+                smt_env, p2, p2, fmgr.And(fmgr.LT(c2, T), fmgr.And(fmgr.Not(P_), fmgr.And(R_, fmgr.Not(S_))))
+            )
+        )
+        expected.transitions[p2].add(
+            PhaseSetsTransition(
+                smt_env, p2, p1, fmgr.And(fmgr.Or(P_, S_), fmgr.And(fmgr.Not(P_), fmgr.Or(S_, fmgr.Not(R_))))
+            )
+        )
+        expected.transitions[p2].add(
+            PhaseSetsTransition(
+                smt_env, p2, p3, fmgr.And(fmgr.LT(c2, T), fmgr.And(fmgr.Not(P_), fmgr.And(fmgr.Not(R_), fmgr.Not(S_))))
+            )
+        )
+        expected.transitions[p2].add(PhaseSetsTransition(smt_env, p2, p4, P_))
         # ct0_st02W
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p3, And(LT(c2, T), And(Not(P_), And(Not(R_), Not(S_))))))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p1, And(Or(P_, S_), And(Not(P_), Or(S_, Not(R_))))))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p2, And(LT(c2, T), And(Not(P_), And(R_, Not(S_))))))
-        expected.transitions[p3].add(PhaseSetsTransition(p3, p4, P_))
+        expected.transitions[p3].add(
+            PhaseSetsTransition(
+                smt_env, p3, p3, fmgr.And(fmgr.LT(c2, T), fmgr.And(fmgr.Not(P_), fmgr.And(fmgr.Not(R_), fmgr.Not(S_))))
+            )
+        )
+        expected.transitions[p3].add(
+            PhaseSetsTransition(
+                smt_env, p3, p1, fmgr.And(fmgr.Or(P_, S_), fmgr.And(fmgr.Not(P_), fmgr.Or(S_, fmgr.Not(R_))))
+            )
+        )
+        expected.transitions[p3].add(
+            PhaseSetsTransition(
+                smt_env, p3, p2, fmgr.And(fmgr.LT(c2, T), fmgr.And(fmgr.Not(P_), fmgr.And(R_, fmgr.Not(S_))))
+            )
+        )
+        expected.transitions[p3].add(PhaseSetsTransition(smt_env, p3, p4, P_))
         # ct0_st
-        expected.transitions[None].add(PhaseSetsTransition(None, p4, P_))
-        expected.transitions[p4].add(PhaseSetsTransition(p4, p4, TRUE()))
+        expected.transitions[None].add(PhaseSetsTransition(smt_env, None, p4, P_))
+        expected.transitions[p4].add(PhaseSetsTransition(smt_env, p4, p4, fmgr.TRUE()))
 
-        actual: PhaseSetsPea = build_automaton(ct)
+        actual: PhaseSetsPea = PeaBuilder(smt_env).build_automaton(ct)
         self.assertEqual(expected, actual, msg="Error while building phase event automaton.")

--- a/hanfor/tests/test_req_simulator/test_scenario.py
+++ b/hanfor/tests/test_req_simulator/test_scenario.py
@@ -2,6 +2,7 @@ import tempfile
 
 from parameterized import parameterized
 from pyfakefs.fake_filesystem_unittest import TestCase
+from pysmt.environment import Environment
 
 from req_simulator.scenario import Scenario
 
@@ -35,8 +36,11 @@ class TestScenario(TestCase):
         path = "/test/file.txt"
         self.fs.create_file(path)
 
-        expected = Scenario.from_object(object)
-        Scenario.save_to_file(expected, path)
-        actual = Scenario.load_from_file(path)
+        smt_env: Environment = Environment()
+        expected = Scenario(smt_env).from_object(object)
+        expected.save_to_file(path)
+        actual = Scenario(smt_env).load_from_file(path)
 
-        self.assertEqual(expected, actual, msg="Error while parsing scenario.")
+        self.assertEqual(expected.variables, actual.variables, msg="Error while parsing scenario.")
+        self.assertEqual(expected.times, actual.times, msg="Error while parsing scenario.")
+        self.assertEqual(expected.types, actual.types, msg="Error while parsing scenario.")

--- a/hanfor/tests/test_req_simulator/test_simulator.py
+++ b/hanfor/tests/test_req_simulator/test_simulator.py
@@ -1,23 +1,22 @@
 from unittest import TestCase
 
 from parameterized import parameterized
-from pysmt.fnode import FNode
-from pysmt.shortcuts import Real, Symbol, GE, Int, Equals
-from pysmt.typing import REAL, INT
+from pysmt.environment import Environment
 
+from lib_core.data import Requirement, Formalization
 from lib_pea.countertrace import CountertraceTransformer
-from lib_pea.countertrace_to_pea import build_automaton
+from lib_pea.countertrace_to_pea import PeaBuilder
 from lib_pea.utils import get_countertrace_parser
 from req_simulator.scenario import Scenario
 from req_simulator.simulator import Simulator
-from lib_core.data import Requirement, Formalization
 from tests.test_req_simulator import test_counter_trace
 
 testcases = [
     (
         "false",
-        test_counter_trace.testcases["false"].expressions,
-        """{
+        lambda smt_env, fmgr, tmgr: (
+            test_counter_trace.pattern_cases(smt_env, "false")[0],
+            """{
         "head": {
             "duration": 6,
             "times": [0.0, 5.0]
@@ -29,11 +28,13 @@ testcases = [
             }
         }
      }""",
+        ),
     ),
     (
         "absence_globally",
-        test_counter_trace.testcases["absence_globally"].expressions,
-        """{
+        lambda smt_env, fmgr, tmgr: (
+            test_counter_trace.pattern_cases(smt_env, "absence_globally")[0],
+            """{
         "head": {
             "duration": 6,
             "times": [0.0, 5.0]
@@ -45,11 +46,13 @@ testcases = [
             }
         }
      }""",
+        ),
     ),
     (
         "absence_before",
-        test_counter_trace.testcases["absence_before"].expressions,
-        """{
+        lambda smt_env, fmgr, tmgr: (
+            test_counter_trace.pattern_cases(smt_env, "absence_before")[0],
+            """{
         "head": {
             "duration": 8,
             "times": [0.0, 3.0, 7.0]
@@ -65,11 +68,17 @@ testcases = [
             }
         }
      }""",
+        ),
     ),
     (
         "response_delay_globally",
-        {"R": Equals(Symbol("x", INT), Int(5)), "S": GE(Symbol("y", REAL), Real(3.14)), "T": Real(5.0)},
-        """{
+        lambda smt_env, fmgr, tmgr: (
+            {
+                "R": fmgr.Equals(fmgr.Symbol("x", tmgr.INT()), fmgr.Int(5)),
+                "S": fmgr.GE(fmgr.Symbol("y", tmgr.REAL()), fmgr.Real(3.14)),
+                "T": fmgr.Real(5.0),
+            },
+            """{
         "head": {
             "duration": 11,
             "times": [0.0, 5.0, 7.0, 10.0]
@@ -85,6 +94,7 @@ testcases = [
             }
         }
      }""",
+        ),
     ),
 ]
 
@@ -92,20 +102,21 @@ testcases = [
 class TestSimulator(TestCase):
 
     @parameterized.expand(testcases)
-    def test_simulator(self, pattern_name: str, expressions: dict[str, FNode], yaml_str: str):
-        _, ct_str, _ = test_counter_trace.testcases[pattern_name]
-        # expressions['T'] = Real(5)
+    def test_simulator(self, pattern_name, tgen):
+        smt_env: Environment = Environment()
+        expressions, yaml_str = tgen(smt_env, smt_env.formula_manager, smt_env.type_manager)
+        _, ct_str, _ = test_counter_trace.pattern_cases(smt_env, pattern_name)
 
-        ct = CountertraceTransformer(expressions).transform(get_countertrace_parser().parse(ct_str))
-        pea = build_automaton(ct)
+        ct = CountertraceTransformer(smt_env, expressions).transform(get_countertrace_parser().parse(ct_str))
+        pea = PeaBuilder(smt_env).build_automaton(ct)
 
         # TODO: Fix this hack.
         pea.requirement = Requirement(rid="0", description="", type_in_csv="", csv_row={}, pos_in_csv=0)
         pea.formalization = Formalization(fid=0)
         pea.countertrace_id = 0
 
-        scenario = Scenario.from_json_string(yaml_str)
-        simulator = Simulator([pea], scenario, test=True)
+        scenario = Scenario(smt_env).from_json_string(yaml_str)
+        simulator = Simulator(smt_env, [pea], scenario, test=True)
 
         actual = False
         for i in range(len(scenario.times)):
@@ -113,9 +124,6 @@ class TestSimulator(TestCase):
 
             if not simulator.check_sat():
                 break
-
-            # if len(simulator.sat_results) != 1:
-            #    break
 
             if i == len(scenario.times) - 1:
                 actual = True

--- a/hanfor/tests/test_req_to_dc.py
+++ b/hanfor/tests/test_req_to_dc.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from unittest import TestCase
 
+from pysmt.environment import Environment
+
 from lib_core.data import Requirement, VariableCollection, Tag, Variable
 from lib_pea.formal_utils import get_semantics_from_requirement
 
@@ -21,7 +23,8 @@ class TestAbsFunction(TestCase):
         )
         self.assertIn("aBooleanVar", [var.name for var in variable_collection.new_vars])
         self.assertIn("anIntegerVar", [var.name for var in variable_collection.new_vars])
-        sem = get_semantics_from_requirement(r, [r], variable_collection)
+        smt_env = Environment()
+        sem = get_semantics_from_requirement(smt_env, r, [r], variable_collection)
         self.assertEqual("True", list(sem.items())[0][1].dc_phases[0].__str__())
         self.assertEqual("⌈((anIntegerVar = 42) & (! aBooleanVar))⌉", list(sem.items())[0][1].dc_phases[1].__str__())
         self.assertEqual("True", list(sem.items())[0][1].dc_phases[2].__str__())
@@ -56,7 +59,8 @@ class TestAbsFunction(TestCase):
         self.assertIn("anIntegerVar", [var.name for var in variable_collection.new_vars])
         self.assertIn("before", [var.name for var in variable_collection.new_vars])
         self.assertIn("after", [var.name for var in variable_collection.new_vars])
-        sem = get_semantics_from_requirement(r, [r], variable_collection)
+        smt_env = Environment()
+        sem = get_semantics_from_requirement(smt_env, r, [r], variable_collection)
         # "true;⌈P⌉;⌈!Q⌉;⌈(!Q && R)⌉;⌈(!Q && !S)⌉ ∧ ℓ > T;true"
         self.assertEqual("True", list(sem.items())[0][1].dc_phases[0].__str__())
         self.assertEqual("⌈before⌉", list(sem.items())[0][1].dc_phases[1].__str__())


### PR DESCRIPTION
Create a new SMT solver for any request, instead of using the singleton instance offered by pysmt.shortcuts. Prevents crashes because of hanfor variables and definitions on smt solver stack diverging.